### PR TITLE
restructure the "Layout" section and sections related to setup() args

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -3,108 +3,171 @@ Tutorial on Packaging and Distributing Projects
 ===============================================
 
 :Page Status: Complete
-:Last Reviewed: 2014-11-11
+:Last Reviewed: 2014-12-31
+
+This tutorial covers the basics of how to configure, package and distribute your
+own Python projects.  It assumes that you are already familiar with the contents
+of the :doc:`installing`.
+
+The tutorial does *not* aim to cover best practices for Python project
+development as a whole.  For example, it does not provide guidance or tool
+recommendations for version control, documentation, or testing.
+
+For a reference material on this topic, see the `Setuptools docs on Building and
+Distributing Packages <http://pythonhosted.org/setuptools/setuptools.html>`_,
+but note that some advisory content there may be outdated. In the event of
+conflicts, prefer the advice in the Python Packaging User Guide.
 
 .. contents:: Contents
    :local:
 
-This tutorial covers the basics of how to create and distribute your
-own Python projects.  It assumes that you are already familiar
-with the contents of the :doc:`installing`.
 
-The tutorial aims to cover core packaging tasks and features and does
-not aim to cover best practices for Python project development as a whole.
-For example, it does not provide guidance or recommendations on selecting
-third-party tools or services such as for documentation, automated
-testing, continuous integration, etc.
+Requirements for Packaging and Distributing
+===========================================
 
-For a reference guide on creating projects, see the `Setuptools guide to
-Building and Distributing Packages
-<http://pythonhosted.org/setuptools/setuptools.html>`_, but note that some
-advisory content there may be outdated. In the event of conflicts, prefer the
-advice in the Python Packaging User Guide.
+1. First, make sure you have already fulfilled the :ref:`requirements for
+   installing packages <installing_requirements>`.
 
+2. Install the "wheel" project [1]_:
 
-Setup for Project Distributors
-==============================
+   ::
 
-This section describes steps to follow before distributing your own
-Python packages.
+    pip install wheel
 
-First, make sure you have already followed the :ref:`setup steps for
-installing packages <installing_setup>`.
+   You'll need this to package your project into :term:`wheels <Wheel>` (see
+   :ref:`below <Packaging Your Project>`).
 
-In addition, you'll need :ref:`wheel` (if you will be building wheels), and
-:ref:`twine`, for uploading to :term:`PyPI <Python Package Index (PyPI)>`.
+3. Install the "twine" project [1]_:
 
-We recommend the following installation sequence:
+   ::
 
-1. For building :term:`wheels <Wheel>`: ``pip install wheel`` [1]_
+    pip install twine
 
-2. For uploading :term:`packages <Distribution Package>`: ``pip install twine``
-[1]_
+   You'll need this to upload your project :term:`distributions <Distribution
+   Package>` to :term:`PyPI <Python Package Index (PyPI)>` (see :ref:`below
+   <Uploading your Project to PyPI>`).
 
 
-Creating your own Project
-=========================
-
-In the sections below, we'll reference the `PyPA sample project
-<https://github.com/pypa/sampleproject>`_, which exists as a companion to this
-tutorial.
+Configuring your Project
+========================
 
 
-Layout
-------
+Initial Files
+-------------
 
-The critical requirement for creating projects using :ref:`setuptools` is to
-have a ``setup.py``. For an example, see `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_.  We'll cover the
-components of ``setup.py`` in the sections below.
+setup.py
+~~~~~~~~
 
-Although it's not required, most projects will organize the code using a `single
-top-level package <https://github.com/pypa/sampleproject/tree/master/sample>`_
-that's named the same as the project.
+The most important file is "setup.py" which exists at the root of your project
+directory. For an example, see the `setup.py
+<https://github.com/pypa/sampleproject/blob/master/setup.py>`_ in the `PyPA
+sample project <https://github.com/pypa/sampleproject>`_.
 
-Additionally, most projects will contain the following files:
+"setup.py" serves two primary functions:
 
-* A `README <https://github.com/pypa/sampleproject/blob/master/README.rst>`_ for
-  explaining the project.
-* A `setup.cfg <https://github.com/pypa/sampleproject/blob/master/setup.cfg>`_
-  that contains option defaults for ``setup.py`` commands.
-* A `MANIFEST.in
-  <https://github.com/pypa/sampleproject/blob/master/MANIFEST.in>`_ that defines
-  additional files to be included in the project distribution when it's
-  packaged.
+1. It's the file where various aspects of your project are configured. The
+   primary feature of ``setup.py`` is that it contains a global ``setup()``
+   function.  The keyword arguments to this function are how specific details of
+   your project are defined.  The most relevant arguments are explained in
+   :ref:`the section below <setup() args>`.
+
+2. It's the command line interface for running various commands that
+   relate to packaging tasks. To get a listing of available commands, run
+   ``python setup.py --help-commands``.
 
 
-Name
-----
+setup.cfg
+~~~~~~~~~
 
-from `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_
+"setup.cfg" is an ini file that contains option defaults for ``setup.py``
+commands.  For an example, see the `setup.cfg
+<https://github.com/pypa/sampleproject/blob/master/setup.cfg>`_ in the `PyPA
+sample project <https://github.com/pypa/sampleproject>`_.
+
+
+README.rst
+~~~~~~~~~~
+
+All projects should contain a readme file that covers the goal of the
+project. The most common format is `reStructuredText
+<http://docutils.sourceforge.net/rst.html>`_ with an "rst" extension, although
+this is not a requirement.
+
+For an example, see `README.rst
+<https://github.com/pypa/sampleproject/blob/master/README.rst>`_ from the `PyPA
+sample project <https://github.com/pypa/sampleproject>`_
+
+MANIFEST.in
+~~~~~~~~~~~
+
+A "MANIFEST.in" is needed in certain cases where you need to package additional
+files that ``python setup.py sdist (or bdist_wheel)`` don't automatically
+include. To see a list of what's included by default, see the `Specifying the
+files to distribute
+<https://docs.python.org/3.4/distutils/sourcedist.html#specifying-the-files-to-distribute>`_
+section from the :ref:`distutils` documentation.
+
+For an example, see the `MANIFEST.in
+<https://github.com/pypa/sampleproject/blob/master/MANIFEST.in>`_ from the `PyPA
+sample project <https://github.com/pypa/sampleproject>`_
+
+
+For details on writing a ``MANIFEST.in`` file, see the `The MANIFEST.in template
+<https://docs.python.org/2/distutils/sourcedist.html#the-manifest-in-template>`_
+section from the :ref:`distutils` documentation.
+
+
+<your package>
+~~~~~~~~~~~~~~
+
+Although it's not required, the most common practice to is to include your
+python modules and packages under a single top-level package that has the same
+:ref:`name <setup() name>` as your project, or something very close.
+
+For an example, see the `sample
+<https://github.com/pypa/sampleproject/tree/master/sample>`_ package that's
+include in the `PyPA sample project <https://github.com/pypa/sampleproject>`_
+
+
+.. _`setup() args`:
+
+setup() args
+------------
+
+As mentioned above, The primary feature of ``setup.py`` is that it contains a
+global ``setup()`` function.  The keyword arguments to this function are how
+specific details of your project are defined.
+
+The most relevant arguments are explained below. The snippets given are taken
+from the `setup.py
+<https://github.com/pypa/sampleproject/blob/master/setup.py>`_ contained in the
+`PyPA sample project <https://github.com/pypa/sampleproject>`_.
+
+
+.. _`setup() name`:
+
+name
+~~~~
 
 ::
 
   name = 'sample'
 
-This will determine how your project is listed on :term:`PyPI <Python Package
-Index (PyPI)>`. For details on permitted characters, see the `name
-<http://legacy.python.org/dev/peps/pep-0426/#name>`_ section from :ref:`PEP426
-<pypa:PEP426s>`.
+This is the name of your project, and will determine how your project is listed
+on :term:`PyPI <Python Package Index (PyPI)>`. For details on permitted
+characters, see the `name <http://legacy.python.org/dev/peps/pep-0426/#name>`_
+section from :ref:`PEP426 <pypa:PEP426s>`.
 
 
-Version
--------
-
-from `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_
+version
+~~~~~~~
 
 ::
 
   version = '1.2.0'
 
 
-Projects should aim to comply with the `version scheme
+Projects should comply with the `version scheme
 <http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers>`_
 specified in :ref:`PEP440 <pypa:PEP440s>`.  Here are some examples:
 
@@ -123,15 +186,102 @@ not duplicate the value, there are a few ways to manage this. See the
 ":ref:`Single sourcing the version`" Advanced Topics section.
 
 
-Packages
---------
+description
+~~~~~~~~~~~
 
-from `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_
+::
+
+  description='A sample Python project',
+  long_description=long_description
+
+Give a short and long description for you project.  These values will be
+displayed on :term:`PyPI <Python Package Index (PyPI)>` if you publish your
+project.
+
+
+url
+~~~
+
+::
+
+  url='https://github.com/pypa/sampleproject'
+
+
+Give a homepage url for your project.
+
+
+author
+~~~~~~
+
+::
+
+  author='The Python Packaging Authority',
+  author_email='pypa-dev@googlegroups.com'
+
+Provide details about the author.
+
+
+license
+~~~~~~~
+
+::
+
+  license='MIT'
+
+Provide the type of license you are using.
+
+
+classifiers
+~~~~~~~~~~~
+
+::
+
+  classifiers=[
+      # How mature is this project? Common values are
+      #   3 - Alpha
+      #   4 - Beta
+      #   5 - Production/Stable
+      'Development Status :: 3 - Alpha',
+
+      # Indicate who your project is intended for
+      'Intended Audience :: Developers',
+      'Topic :: Software Development :: Build Tools',
+
+      # Pick your license as you wish (should match "license" above)
+       'License :: OSI Approved :: MIT License',
+
+      # Specify the Python versions you support here. In particular, ensure
+      # that you indicate whether you support Python 2, Python 3 or both.
+      'Programming Language :: Python :: 2',
+      'Programming Language :: Python :: 2.6',
+      'Programming Language :: Python :: 2.7',
+      'Programming Language :: Python :: 3',
+      'Programming Language :: Python :: 3.2',
+      'Programming Language :: Python :: 3.3',
+      'Programming Language :: Python :: 3.4',
+  ]
+
+Provide a list of classifiers the categorize your project. For a full listing,
+see https://pypi.python.org/pypi?%3Aaction=list_classifiers.
+
+
+keywords
+~~~~~~~~
+
+::
+
+  keywords='sample setuptools development'
+
+List keywords that describe your project.
+
+
+packages
+~~~~~~~~
 
 ::
 
   packages=find_packages(exclude=['contrib', 'docs', 'tests*'])
+
 
 It's required to list the :term:`packages <Import Package>` to be included
 in your project.  Although they can be listed manually,
@@ -140,66 +290,8 @@ keyword argument to omit packages that are not intended to be released and
 installed.
 
 
-Metadata
---------
-
-It's important to include various metadata about your project.
-
-from `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_
-
-::
-
-    # A description of your project
-    description='A sample Python project',
-    long_description=long_description,
-
-    # The project's main homepage
-    url='https://github.com/pypa/sampleproject',
-
-    # Author details
-    author='The Python Packaging Authority',
-    author_email='pypa-dev@googlegroups.com',
-
-    # Choose your license
-    license='MIT',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
-
-        # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-
-        # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: MIT License',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-    ],
-
-    # What does your project relate to?
-    keywords='sample setuptools development'
-
-
-
-Dependencies
-------------
-
-from `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_
+install_requires
+~~~~~~~~~~~~~~~~
 
 ::
 
@@ -214,16 +306,8 @@ For more on using "install_requires" see :ref:`install_requires vs Requirements 
 
 .. _`Package Data`:
 
-Package Data
-------------
-
-Often, additional files need to be installed into a :term:`package <Import Package>`. These files are often data that’s closely related to the
-package’s implementation, or text files containing documentation that might be
-of interest to programmers using the package. These files are called "package
-data".
-
-from `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_
+package_data
+~~~~~~~~~~~~
 
 ::
 
@@ -231,6 +315,11 @@ from `sampleproject/setup.py
      'sample': ['package_data.dat'],
  }
 
+
+Often, additional files need to be installed into a :term:`package <Import
+Package>`. These files are often data that’s closely related to the package’s
+implementation, or text files containing documentation that might be of interest
+to programmers using the package. These files are called "package data".
 
 The value must be a mapping from package name to a list of relative path names
 that should be copied into the package. The paths are interpreted as relative to
@@ -243,19 +332,16 @@ the `setuptools docs <http://pythonhosted.org/setuptools/setuptools.html>`_.
 
 .. _`Data Files`:
 
-Data Files
-----------
-
-Although configuring :ref:`Package Data` is sufficient for most needs, in some
-cases you may need to place data files *outside* of your :term:`packages
-<Import Package>`.  The ``data_files`` directive allows you to do that.
-
-from `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_
+data_files
+~~~~~~~~~~
 
 ::
 
     data_files=[('my_data', ['data/data_file'])]
+
+Although configuring :ref:`Package Data` is sufficient for most needs, in some
+cases you may need to place data files *outside* of your :term:`packages
+<Import Package>`.  The ``data_files`` directive allows you to do that.
 
 Each (directory, files) pair in the sequence specifies the installation
 directory and the files to install there. If directory is a relative path, it is
@@ -278,11 +364,40 @@ For more information see the distutils section on `Installing Additional Files
   <https://bitbucket.org/pypa/wheel/issue/92>`_.
 
 
-Scripts
--------
+scripts
+~~~~~~~
 
-from `sampleproject/setup.py
-<https://github.com/pypa/sampleproject/blob/master/setup.py>`_
+Although ``setup()`` supports a `scripts
+<http://docs.python.org/3.4/distutils/setupscript.html#installing-scripts>`_
+keyword for pointing to pre-made scripts to install, the recommended approach to
+achieve cross-platform compatibility is to use :ref:`console_scripts` entry
+points (see below).
+
+
+entry_points
+~~~~~~~~~~~~
+
+::
+
+  entry_points={
+    ...
+  }
+
+
+Use this keyword to specify any plugins that your project provides for any named
+entry points that may be defined by your project or others that you depend on.
+
+For more information, see the section on `Dynamic Discovery of Services and
+Plugins
+<http://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
+from the :ref:`setuptools` docs.
+
+The most commonly used entry point is "console_scripts" (see below).
+
+.. _`console_scripts`:
+
+console_scripts
+***************
 
 ::
 
@@ -292,12 +407,9 @@ from `sampleproject/setup.py
       ],
   }
 
-Although ``setup.py`` supports a `scripts
-<http://docs.python.org/3.4/distutils/setupscript.html#installing-scripts>`_
-keyword for pointing to pre-made scripts, the recommended approach to achieve
-cross-platform compatibility is to use "console_script" `entry points
+Use "console_script" `entry points
 <http://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
-that register your script interfaces. You can then let the toolchain handle the
+to register your script interfaces. You can then let the toolchain handle the
 work of turning these interfaces into actual scripts [2]_.  The scripts will be
 generated during the install of your :term:`distribution <Distribution
 Package>`.
@@ -307,41 +419,38 @@ For more information, see `Automatic Script Creation
 from the `setuptools docs <http://pythonhosted.org/setuptools/setuptools.html>`_.
 
 
-MANIFEST.in
------------
 
-A ``MANIFEST.in`` file is needed in certain cases where you need to package
-additional files that ``python setup.py sdist (or bdist_wheel)`` don't
-automatically include.
-
-To see a list of what's included by default, see the `Specifying the files to
-distribute
-<https://docs.python.org/3.4/distutils/sourcedist.html#specifying-the-files-to-distribute>`_
-section from the :ref:`distutils` documentation.
-
-For details on writing a ``MANIFEST.in`` file, see the `The MANIFEST.in template
-<https://docs.python.org/2/distutils/sourcedist.html#the-manifest-in-template>`_
-section from the :ref:`distutils` documentation.
-
-
-Developing your project
-=======================
+Working in "Development Mode"
+=============================
 
 Although not required, it's common to locally install your project in "develop"
 or "editable" mode while you're working on it.  This allows the project to be
 both installed and editable in project form.
 
+Using "setup.py", run the following:
+
 ::
 
- cd myproject
- python setup.py develop    # the setuptools way
- pip install -e .           # the pip way (which just calls "setup.py develop")
+ python setup.py develop
+
+
+Or you can achieve the same result using :ref:`pip`:
+
+::
+
+ pip install -e .
+
+
+Note that both commands will install any dependencies declared with
+"install_requires" and also any scripts declared with "console_scripts".
 
 
 For more information, see the `Development Mode
 <http://pythonhosted.org/setuptools/setuptools.html#development-mode>`_ section
 of the `setuptools docs <http://pythonhosted.org/setuptools/setuptools.html>`_.
 
+
+.. _`Packaging Your Project`:
 
 Packaging your Project
 ======================
@@ -431,6 +540,8 @@ OSX, or Windows, usually due to containing compiled extensions.
   exist across linux distros.
 
 
+.. _`Uploading your Project to PyPI`:
+
 Uploading your Project to PyPI
 ==============================
 
@@ -441,6 +552,7 @@ Uploading your Project to PyPI
   which is cleaned on a semi regular basis. See
   `these instructions <https://wiki.python.org/moin/TestPyPI>`_ on how
   to setup your configuration in order to use it.
+
 
 First, you need a :term:`PyPI <Python Package Index (PyPI)>` user
 account. There are two options:

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -5,9 +5,6 @@ Tutorial on Installing Packages
 :Page Status: Incomplete
 :Last Reviewed: 2014-12-24
 
-.. contents:: Contents
-   :local:
-
 This tutorial covers the basics of how to install Python :term:`packages
 <Distribution Package>`.
 
@@ -21,10 +18,14 @@ is often not preferred, because it can easily be confused with a Linux
 distribution, or another larger software distribution like Python itself.
 
 
-.. _installing_setup:
+.. contents:: Contents
+   :local:
 
-Setup for Installing Packages
-=============================
+
+.. _installing_requirements:
+
+Requirements for Installing Packages
+====================================
 
 This section describes the steps to follow before installing other Python
 packages.


### PR DESCRIPTION
 many edits to the packaging tutorial, with the 2 main changes being:

 1. redo the "Layout" section into a section on the "Initial Files".
 2. restructured the info on setup args into literal sections by arg name

built html:  https://packaging.python.org/en/setup_args/distributing.html