### PR TITLE
don't call our intro sections "tutorials", because they're not

### DIFF
--- a/source/additional.rst
+++ b/source/additional.rst
@@ -5,8 +5,8 @@ Advanced Topics
 :Last Reviewed: 2014-12-24
 
 This section covers a variety of packaging concepts and topics that don't fit
-neatly into the documentation of any particular tool or one of the two
-tutorials.
+neatly into the documentation of any particular :ref:`project <projects>` or in
+either of our guides on :doc:`installing` or :doc:`distributing`.
 
 .. toctree::
    :maxdepth: 1

--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -1,15 +1,15 @@
-===============================================
-Tutorial on Packaging and Distributing Projects
-===============================================
+===================================
+Packaging and Distributing Projects
+===================================
 
 :Page Status: Complete
 :Last Reviewed: 2014-12-31
 
-This tutorial covers the basics of how to configure, package and distribute your
+This section covers the basics of how to configure, package and distribute your
 own Python projects.  It assumes that you are already familiar with the contents
 of the :doc:`installing`.
 
-The tutorial does *not* aim to cover best practices for Python project
+The section does *not* aim to cover best practices for Python project
 development as a whole.  For example, it does not provide guidance or tool
 recommendations for version control, documentation, or testing.
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -214,8 +214,8 @@ Glossary
 
         An isolated Python environment that allows packages to be installed for
         use by a particular application, rather than being installed system
-        wide. For more information, see the tutorial section on :ref:`Creating
-        and using Virtual Environments`.
+        wide. For more information, see the section on :ref:`Creating and using
+        Virtual Environments`.
 
     Wheel
 

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -1,11 +1,11 @@
-===============================
-Tutorial on Installing Packages
-===============================
+===================
+Installing Packages
+===================
 
 :Page Status: Incomplete
 :Last Reviewed: 2014-12-24
 
-This tutorial covers the basics of how to install Python :term:`packages
+This section covers the basics of how to install Python :term:`packages
 <Distribution Package>`.
 
 It's important to note that the term "package" in this context is being used as

--- a/source/projects.rst
+++ b/source/projects.rst
@@ -312,8 +312,8 @@ venv
 
 A package in the Python Standard Library (starting with Python 3.3) that
 includes the ``pyvenv`` tool for creating :term:`Virtual Environments <Virtual
-Environment>`.  For more information, see the tutorial section on :ref:`Creating
-and using Virtual Environments`.
+Environment>`.  For more information, see the section on :ref:`Creating and
+using Virtual Environments`.
 
 
 ----

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -4,4 +4,4 @@
 Quickstart
 ==========
 
-This content has moved to the :doc:`tutorial`.
+This content has moved to the :doc:`installing` and :doc:`distributing`.


### PR DESCRIPTION
our intro sections aren't "tutorials" right now, so let's not set up a false expectation for the reader.

tutorials involve literal tasks that the reader is guided though with clear results and checks along the way.

whether they should be tutorials or not is another matter, but they're not currently.  I don't have any plans to make them true tutorials.   I can imagine having actual tutorials in the advanced section for certain topics possibly.

In the title, I simply remove the word "Tutorial", but in the text, I replaced "tutorial" with "section".

this does not break any external inbound links.