### PR TITLE
Use A.B.x labels for pre-installed versions

### DIFF
--- a/source/code/appveyor.yml
+++ b/source/code/appveyor.yml
@@ -7,30 +7,34 @@ environment:
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
 
   matrix:
+
+    # Pre-installed Python versions, which Appveyor may upgrade to
+    # a later point release.
+
     - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.8"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.5"
+      PYTHON_VERSION: "3.3.x" # currently 3.3.5
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.8"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.0"
 
     - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.5"
+      PYTHON_VERSION: "3.3.x" # currently 3.3.5
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 
     - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 


### PR DESCRIPTION
The labels of the pre-installed versions are currently wrong for 2.7
and 3.4, as Appveyor has updated the version, and install.ps1 does not
override the pre-installed version.