### PR TITLE
Add 2.6.6 to the Appveyor build matrix

### DIFF
--- a/source/code/appveyor.yml
+++ b/source/code/appveyor.yml
@@ -34,6 +34,13 @@ environment:
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 
+    # Also build on a Python version not pre-installed by Appveyor.
+    # See: https://github.com/ogrisel/python-appveyor-demo/issues/10
+
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 


### PR DESCRIPTION
Packagers may be needing to do a Python 2.6 Win32 release.