### PR TITLE
Remove wheel reference in tool recommendations

### DIFF
--- a/source/current.rst
+++ b/source/current.rst
@@ -20,11 +20,6 @@ Installation Tool Recommendations
 * Use :ref:`virtualenv`, or `pyvenv`_ to isolate application specific
   dependencies from a shared Python installation. [3]_
 
-* Use `pip wheel
-  <http://pip.pypa.io/en/latest/reference/pip_wheel.html>`_ to create a
-  cache of :term:`wheel` distributions, for the purpose of speeding up
-  subsequent installations. [4]_
-
 * If you're looking for management of fully integrated cross-platform software
   stacks, consider :ref:`buildout` (primarily focused on the web development
   community) or :ref:`hashdist`, or :ref:`conda` (both primarily focused on
@@ -36,11 +31,11 @@ Packaging Tool Recommendations
 ==============================
 
 * Use :ref:`setuptools` to define projects and create :term:`Source Distributions
-  <Source Distribution (or "sdist")>`. [5]_ [6]_
+  <Source Distribution (or "sdist")>`. [4]_ [5]_
 
 * Use the ``bdist_wheel`` :ref:`setuptools` extension available from the
   :ref:`wheel project <wheel>` to create :term:`wheels <Wheel>`.  This is
-  especially beneficial, if your project contains binary extensions. [7]_
+  especially beneficial, if your project contains binary extensions. [6]_
 
 * Use `twine <https://pypi.python.org/pypi/twine>`_ for uploading distributions
   to :term:`PyPI <Python Package Index (PyPI)>`.
@@ -64,10 +59,7 @@ Packaging Tool Recommendations
        :ref:`virtualenv`. However, using :ref:`virtualenv` will still be
        recommended for users that need cross-version consistency.
 
-.. [4] For more information, see the pip guide to `Installing from Wheels
-       <https://pip.pypa.io/en/latest/user_guide.html#installing-from-wheels>`_.
-
-.. [5] Although you can use pure ``distutils`` for many projects, it does not
+.. [4] Although you can use pure ``distutils`` for many projects, it does not
        support defining dependencies on other projects and is missing several
        convenience utilities for automatically populating distribution metadata
        correctly that are provided by ``setuptools``. Being outside the
@@ -81,11 +73,11 @@ Packaging Tool Recommendations
        from a prebuilt :term:`wheel <Wheel>` file), it will actually build
        your project using :ref:`setuptools` instead.
 
-.. [6] `distribute`_ (a fork of setuptools) was merged back into
+.. [5] `distribute`_ (a fork of setuptools) was merged back into
        :ref:`setuptools` in June 2013, thereby making setuptools the default
        choice for packaging.
 
-.. [7] :term:`PyPI <Python Package Index (PyPI)>` currently only allows
+.. [6] :term:`PyPI <Python Package Index (PyPI)>` currently only allows
        uploading Windows and Mac OS X wheels, and they should be compatible with
        the binary installers provided for download from python.org. Enhancements
        will have to be made to the :ref:`wheel compatibility tagging scheme


### PR DESCRIPTION
This was a recommendation for speeding up subsequent installations, but `pip` now automatically builds wheels in a cache since 7.0, so there's questionable utility in keeping it here.