### PR TITLE
easy_install has a -x option to exclude scripts from the install

### DIFF
--- a/source/pip_easy_install.rst
+++ b/source/pip_easy_install.rst
@@ -57,6 +57,9 @@ Here's a breakdown of the important differences between pip and easy_install now
 |:ref:`Multi-version Installs` |No                                |Yes                            |
 |                              |                                  |                               |
 +------------------------------+----------------------------------+-------------------------------+
+|Exclude scripts during install|No                                |Yes                            |
+|                              |                                  |                               |
++------------------------------+----------------------------------+-------------------------------+
 
 ----
 


### PR DESCRIPTION
In writing a project which includes console-scripts, I wanted to install the package but not have it generate the scripts. In reading the help for pip, I don't see any option to exclude the script installation. I believe that reveals another difference between easy_install and pip.