### PR TITLE
Installation Tutorial updates

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -414,6 +414,8 @@ For more information, see `Automatic Script Creation
 <http://pythonhosted.org/setuptools/setuptools.html#automatic-script-creation>`_
 from the `setuptools docs <http://pythonhosted.org/setuptools/setuptools.html>`_.
 
+.. _`Choosing a versioning scheme`:
+
 Choosing a versioning scheme
 ----------------------------
 

--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -28,16 +28,7 @@ Requirements for Packaging and Distributing
 1. First, make sure you have already fulfilled the :ref:`requirements for
    installing packages <installing_requirements>`.
 
-2. Install "wheel" [1]_:
-
-   ::
-
-    pip install wheel
-
-   You'll need this to package your project into :term:`wheels <Wheel>` (see
-   :ref:`below <Packaging Your Project>`).
-
-3. Install "twine" [1]_:
+2. Install "twine" [1]_:
 
    ::
 

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -32,7 +32,7 @@ packages.
 
 1. Install :ref:`pip`, :ref:`setuptools`, and :ref:`wheel`:
 
-   If you have Python >=2.7.9 or Python>=3.4:
+   If you have Python 2 >=2.7.9 or Python 3 >=3.4:
 
      You may already have the ``pip`` command available by default (and
      setuptools will be installed as well), or you may at least contain a

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -197,7 +197,7 @@ Source Distributions vs Wheels
 
 :ref:`pip` can install from either :term:`Source Distributions (sdist) <Source
 Distribution (or "sdist")>` or :term:`Wheels <Wheel>`, but if both are present
-on PyPI, pip will prefer the :term:`wheel <Wheel>`.
+on PyPI, pip will prefer a compatible :term:`wheel <Wheel>`.
 
 :term:`Wheels <Wheel>` are a pre-built :term:`distribution <Distribution
 Package>` format that provides faster installation compared to :term:`Source

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -50,6 +50,14 @@ packages.
      not installed already. To upgrade an existing setuptools and wheel, run
      ``pip install -U setuptools wheel`` [2]_
 
+     .. warning::
+
+        Be cautious if you're using a Python install that's managed by your
+        operating system or another package manager. get-pip.py does not
+        coordinate with those tools, and may leave your system in an
+        inconsistent state.
+
+
 2. Optionally, Create a virtual environment (See :ref:`section below <Creating
    and using Virtual Environments>` for details):
 

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -32,9 +32,10 @@ packages.
 
 1. Install :ref:`pip` and :ref:`setuptools`: [3]_
 
-   If you have a :ref:`PEP453 <pypa:PEP453s>`-compliant Python 3.4, it may
-   already have the ``pip`` command available by default (and setuptools will be
-   installed as well), or it may at least contain a working `ensurepip
+   If you have Python 2.7.9 and later (in the Python 2 series), or Python 3.4
+   and later (in the Python 3 series), it may already have the ``pip`` command
+   available by default (and setuptools will be installed as well), or it may at
+   least contain a working `ensurepip
    <https://docs.python.org/3.4/library/ensurepip.html>`_. To install pip (and
    setuptools) using ensurepip, run: ``python -m ensurepip --upgrade``.
 

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -30,14 +30,15 @@ Requirements for Installing Packages
 This section describes the steps to follow before installing other Python
 packages.
 
-1. Install :ref:`pip` and :ref:`setuptools`: [3]_
+1. Install :ref:`pip`, :ref:`setuptools`, and :ref:`wheel`: [3]_
 
    If you have Python 2.7.9 and later (in the Python 2 series), or Python 3.4
    and later (in the Python 3 series), it may already have the ``pip`` command
    available by default (and setuptools will be installed as well), or it may at
    least contain a working `ensurepip
    <https://docs.python.org/3.4/library/ensurepip.html>`_. To install pip (and
-   setuptools) using ensurepip, run: ``python -m ensurepip --upgrade``.
+   setuptools) using ensurepip, run: ``python -m ensurepip --upgrade``.  Then
+   install :ref:`wheel`: ``pip install wheel``
 
    Otherwise:
 
@@ -45,8 +46,9 @@ packages.
      <https://raw.github.com/pypa/pip/master/contrib/get-pip.py>`_ [1]_
 
    * Run ``python get-pip.py``.  This will install or upgrade pip.
-     Additionally, it will install setuptools if it's not installed already. To
-     upgrade an existing setuptools, run ``pip install -U setuptools`` [2]_
+     Additionally, it will install :ref:`setuptools` and :ref:`wheel` if they're
+     not installed already. To upgrade an existing setuptools and wheel, run
+     ``pip install -U setuptools wheel`` [2]_
 
 2. Optionally, Create a virtual environment (See :ref:`section below <Creating
    and using Virtual Environments>` for details):

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -2,8 +2,8 @@
 Installing Packages
 ===================
 
-:Page Status: Incomplete
-:Last Reviewed: 2014-12-24
+:Page Status: Complete
+:Last Reviewed: 2015-09-09
 
 This section covers the basics of how to install Python :term:`packages
 <Distribution Package>`.
@@ -192,6 +192,23 @@ In this case, this means to install any version "==1.4.*" version that's also
 ">=1.4.2".
 
 
+Source Distributions vs Wheels
+==============================
+
+:ref:`pip` can install from either :term:`Source Distributions (sdist) <Source
+Distribution (or "sdist")>` or :term:`Wheels <Wheel>`, but if both are present
+on PyPI, pip will prefer the :term:`wheel <Wheel>`.
+
+:term:`Wheels <Wheel>` are a pre-built :term:`distribution <Distribution
+Package>` format that provides faster installation compared to :term:`Source
+Distributions (sdist) <Source Distribution (or "sdist")>`, especially when a
+project contains compiled extensions.
+
+If :ref:`pip` does not find a wheel to install, it will locally build a wheel
+and cache it for future installs, instead of rebuilding the source distribution
+in the future.
+
+
 Upgrading packages
 ==================
 
@@ -201,37 +218,6 @@ Upgrade an already installed `SomeProject` to the latest from PyPI.
 
  pip install --upgrade SomeProject
 
-
-Installing Cached Wheels
-========================
-
-:term:`Wheel` is a pre-built :term:`distribution <Distribution Package>` format that
-provides faster installation compared to :term:`Source Distributions (sdist)
-<Source Distribution (or "sdist")>`, especially when a project contains compiled
-extensions.
-
-As of v1.5, :ref:`pip` prefers :term:`wheels <Wheel>` over :term:`sdists <Source
-Distribution (or "sdist")>` when searching indexes.
-
-Although wheels are `becoming more common <http://pythonwheels.com>`_ on
-:term:`PyPI <Python Package Index (PyPI)>`, if you want all of your dependencies
-converted to wheel, do the following (assuming you're using a :ref:`Requirements
-File <pip:Requirements Files>`):
-
-::
-
- pip wheel --wheel-dir=/local/wheels -r requirements.txt
-
-And then to install those requirements just using your local directory of wheels
-(and not from PyPI):
-
-::
-
- pip install --no-index --find-links=/local/wheels -r requirements.txt
-
-
-:term:`Wheel` is intended to replace :term:`Eggs <Egg>`.  For a detailed
-comparison, see :ref:`Wheel vs Egg`.
 
 
 Installing to the User Site

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -30,25 +30,27 @@ Requirements for Installing Packages
 This section describes the steps to follow before installing other Python
 packages.
 
-1. Install :ref:`pip`, :ref:`setuptools`, and :ref:`wheel`: [3]_
+1. Install :ref:`pip`, :ref:`setuptools`, and :ref:`wheel`:
 
-   If you have Python 2.7.9 and later (in the Python 2 series), or Python 3.4
-   and later (in the Python 3 series), it may already have the ``pip`` command
-   available by default (and setuptools will be installed as well), or it may at
-   least contain a working `ensurepip
-   <https://docs.python.org/3.4/library/ensurepip.html>`_. To install pip (and
-   setuptools) using ensurepip, run: ``python -m ensurepip --upgrade``.  Then
-   install :ref:`wheel`: ``pip install wheel``
+   If you have Python >=2.7.9 or Python>=3.4:
+
+     You may already have the ``pip`` command available by default (and
+     setuptools will be installed as well), or you may at least contain a
+     working `ensurepip
+     <https://docs.python.org/3.4/library/ensurepip.html>`_. To install pip (and
+     setuptools) using ensurepip, run: ``python -m ensurepip --upgrade``.
+
+     Since :ref:`wheel` won't be installed, you'll also need to run: ``pip
+     install wheel``
 
    Otherwise:
 
    * Securely Download `get-pip.py
      <https://raw.github.com/pypa/pip/master/contrib/get-pip.py>`_ [1]_
 
-   * Run ``python get-pip.py``.  This will install or upgrade pip.
+   * Run ``python get-pip.py``. [2]_  This will install or upgrade pip.
      Additionally, it will install :ref:`setuptools` and :ref:`wheel` if they're
-     not installed already. To upgrade an existing setuptools and wheel, run
-     ``pip install -U setuptools wheel`` [2]_
+     not installed already.
 
      .. warning::
 
@@ -69,7 +71,7 @@ packages.
     virtualenv <DIR>
     source <DIR>/bin/activate
 
-   Using `pyvenv`_: [4]_
+   Using `pyvenv`_: [3]_
 
    ::
 
@@ -180,7 +182,7 @@ To install greater than or equal to one version and less than another:
 
 To install a version that's `"compatible"
 <https://www.python.org/dev/peps/pep-0440/#compatible-release>`_ with a certain
-version: [5]_
+version: [4]_
 
 ::
 
@@ -369,18 +371,12 @@ Install `setuptools extras`_.
        installs the default behavior
        <https://github.com/pypa/pip/issues/1668>`_.
 
-.. [3] On Linux and OSX, pip and setuptools will usually be available for the system
-       python from a system package manager (e.g. `yum` or `apt-get` for linux,
-       or `homebrew` for OSX). Unfortunately, there is often delay in getting
-       the latest version this way, so in most cases, you'll want to use these
-       instructions.
-
-.. [4] Beginning with Python 3.4, ``pyvenv`` (a stdlib alternative to
+.. [3] Beginning with Python 3.4, ``pyvenv`` (a stdlib alternative to
        :ref:`virtualenv`) will create virtualenv environments with ``pip``
        pre-installed, thereby making it an equal alternative to
        :ref:`virtualenv`.
 
-.. [5] The compatible release specifier was accepted in :ref:`PEP440
+.. [4] The compatible release specifier was accepted in :ref:`PEP440
        <pypa:PEP440s>` and support was released in :ref:`setuptools` v8.0 and
        :ref:`pip` v6.0
 


### PR DESCRIPTION
- The installation tutorial now covers installing wheel, since it's critical for wheel caching
- Mention that Python 2.7.9 has pip bootstrapping
- replace the old "pip wheel" caching instructions with general info about wheels and that pip has a wheel cache
- add a warning about using `get-pip.py` in managed pythons