### PR TITLE
update IUS links

### DIFF
--- a/source/install_requirements_linux.rst
+++ b/source/install_requirements_linux.rst
@@ -108,9 +108,9 @@ To install pip, wheel, and setuptools, in a parallel, non-system environment
 
    Be aware that collections may not contain the most recent versions.
 
-2. Enable the `IUS repository <https://iuscommunity.org/pages/Repos.html>`_ and
+2. Enable the `IUS repository <https://ius.io/GettingStarted/>`_ and
    install one of the `parallel-installable
-   <https://iuscommunity.org/pages/TheSafeRepoInitiative.html#parallel-installable-packages>`_
+   <https://ius.io/SafeRepo/#parallel-installable-package>`_
    Pythons, along with pip, setuptools, and wheel, which are kept fairly up to
    date.
 


### PR DESCRIPTION
The IUS project has launched a [new website](https://ius.io).  Here are some URL corrections.