### PR TITLE
add note about --no-deps in develop mode.

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -544,9 +544,13 @@ Or you can achieve the same result using :ref:`pip`:
  pip install -e .
 
 
-Note that both commands will install any dependencies declared with
-"install_requires" and also any scripts declared with "console_scripts".
+Note that both commands will install any dependencies declared with "install_requires"
+and also any scripts declared with "console_scripts".  If you do not want dependencies
+installed, you can pass the ``--no-deps`` flag to setup.py:
 
+::
+
+ python setup.py develop --no-deps
 
 For more information, see the `Development Mode
 <http://pythonhosted.org/setuptools/setuptools.html#development-mode>`_ section


### PR DESCRIPTION
Adding a note about the no-deps option for develop mode -- I, at least, find this is usually what I want. (maybe because I use conda to handle dependencies...). but it took me a while to find it back in the day.