### PR TITLE
Replace "binstar.org" with "anaconda.org"

### DIFF
--- a/source/projects.rst
+++ b/source/projects.rst
@@ -235,7 +235,7 @@ many of their combined features in terms of package management, virtual environm
 management and deployment of binary extensions.
 
 Conda does not install packages from PyPI and can install only from
-the official Continuum repositories, or binstar.org (a place for
+the official Continuum repositories, or anaconda.org (a place for
 user-contributed *conda* packages), or a local (e.g. intranet) package server.
 However, note that pip can be installed into, and work side-by-side with conda
 for managing distributions from PyPI.


### PR DESCRIPTION
The user-contributed repository for *conda* packages formerly named binstar.org is now called anaconda.org, and the domain http://binstar.org redirects to http://anaconda.org.