### PR TITLE
Update copyright year

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Python Packaging User Guide'
-copyright = u'2013, PyPA'
+copyright = u'2013–2015, PyPA'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
A tiny change to add the current year to the copyright statement, like that of other python.org pages.