### PR TITLE
Fix undefined label build warnings

### DIFF
--- a/source/current.rst
+++ b/source/current.rst
@@ -50,11 +50,10 @@ Packaging Tool Recommendations
        (which pip doesn't support).  For a detailed breakdown, see :ref:`pip vs
        easy_install`.
 
-.. [2] The acceptance of :ref:`PEP453 <pypa:PEP453s>` means that :ref:`pip`
+.. [2] The acceptance of :pep:`453` means that :ref:`pip`
        will be available by default in most installations of Python 3.4 or
-       later.  See the `rationale section
-       <http://www.python.org/dev/peps/pep-0453/#rationale>`_ from :ref:`PEP453
-       <pypa:PEP453s>` as for why pip was chosen.
+       later.  See the :pep:`rationale section <453#rationale>` from :pep:`453`
+       as for why pip was chosen.
 
 .. [3] :ref:`get-pip.py <pip:get-pip>` and :ref:`virtualenv` install
        :ref:`wheel`, whereas :ref:`ensurepip` and :ref:`pyvenv <venv>` do not
@@ -87,8 +86,8 @@ Packaging Tool Recommendations
 .. [7] :term:`PyPI <Python Package Index (PyPI)>` currently only allows
        uploading Windows and Mac OS X wheels, and they should be compatible with
        the binary installers provided for download from python.org. Enhancements
-       will have to be made to the :ref:`wheel compatibility tagging scheme
-       <pypa:PEP425s>` before linux wheels will be allowed.
+       will have to be made to the :pep:`wheel compatibility tagging scheme
+       <425>` before linux wheels will be allowed.
 
 .. _distribute: https://pypi.python.org/pypi/distribute
 .. _pyvenv: http://docs.python.org/3.4/library/venv.html

--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -146,8 +146,8 @@ name
 
 This is the name of your project, and will determine how your project is listed
 on :term:`PyPI <Python Package Index (PyPI)>`. For details on permitted
-characters, see the `name <http://legacy.python.org/dev/peps/pep-0426/#name>`_
-section from :ref:`PEP426 <pypa:PEP426s>`.
+characters, see the :pep:`name <426#name>`
+section from :pep:`426`.
 
 
 version
@@ -414,9 +414,9 @@ Standards compliance for interoperability
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Different Python projects may use different versioning schemes based on the needs of that
-particular project, but all of them are required to comply with the flexible `public version
-scheme <https://www.python.org/dev/peps/pep-0440/#public-version-identifiers>`_ specified
-in :ref:`PEP440 <pypa:PEP440s>` in order to be supported in tools and libraries like ``pip``
+particular project, but all of them are required to comply with the flexible :pep:`public version
+scheme <440#public-version-identifiers>` specified
+in :pep:`440` in order to be supported in tools and libraries like ``pip``
 and ``setuptools``.
 
 Here are some examples of compliant version numbers::
@@ -431,8 +431,8 @@ Here are some examples of compliant version numbers::
   23          # Serial release
 
 To further accommodate historical variations in approaches to version numbering,
-:ref:`PEP440 <pypa:PEP440s>` also defines a comprehensive technique for `version
-normalisation <https://www.python.org/dev/peps/pep-0440/#normalization>`_ that maps
+:pep:`440` also defines a comprehensive technique for :pep:`version
+normalisation <440#normalization>` that maps
 variant spellings of different version numbers to a standardised canonical form.
 
 Scheme choices
@@ -452,8 +452,8 @@ where the project author increments:
 2. MINOR version when they add functionality in a backwards-compatible manner, and
 3. MAINTENANCE version when they make backwards-compatible bug fixes.
 
-Adopting this approach as a project author allows users to make use of `"compatible release"
-<https://www.python.org/dev/peps/pep-0440/#compatible-release>`_ specifiers, where
+Adopting this approach as a project author allows users to make use of :pep:`"compatible release"
+<440#compatible-release>` specifiers, where
 ``name ~= X.Y`` requires at least release X.Y, but also allows any later release with
 a matching MAJOR version.
 
@@ -511,8 +511,8 @@ Local version identifiers
 
 Public version identifiers are designed to support distribution via
 :term:`PyPI <Python Package Index (PyPI)>`. Python's software distribution tools also support
-the notion of a `local version identifier
-<https://www.python.org/dev/peps/pep-0440/#local-version-identifiers>`_, which can be used to
+the notion of a :pep:`local version identifier
+<440#local-version-identifiers>`, which can be used to
 identify local development builds not intended for publication, or modified variants of a release
 maintained by a redistributor.
 
@@ -674,7 +674,7 @@ To build the wheel:
 `bdist_wheel` will detect that the code is pure Python, and build a wheel that's
 named such that it's usable on any Python installation with the same major
 version (Python 2 or Python 3) as the version you used to build the wheel.  For
-details on the naming of wheel files, see :ref:`PEP425 <pypa:PEP425s>`
+details on the naming of wheel files, see :pep:`425`
 
 If your code supports both Python 2 and 3, but with different code (e.g., you
 use `"2to3" <https://docs.python.org/2/library/2to3.html>`_) you can run
@@ -700,13 +700,13 @@ To build the wheel:
 
 `bdist_wheel` will detect that the code is not pure Python, and build a wheel
 that's named such that it's only usable on the platform that it was built
-on. For details on the naming of wheel files, see :ref:`PEP425 <pypa:PEP425s>`
+on. For details on the naming of wheel files, see :pep:`425`
 
 .. note::
 
   :term:`PyPI <Python Package Index (PyPI)>` currently only allows uploads of
   platform wheels for Windows and OS X, NOT linux.  Currently, the wheel tag
-  specification (:ref:`PEP425 <pypa:PEP425s>`) does not handle the variation that can
+  specification (:pep:`425`) does not handle the variation that can
   exist across linux distros.
 
 
@@ -817,6 +817,6 @@ There are two options:
 
 .. [2] Specifically, the "console_script" approach generates ``.exe`` files on
        Windows, which are necessary because the OS special-cases ``.exe`` files.
-       Script-execution features like ``PATHEXT`` and the `Python Launcher for
-       Windows <http://legacy.python.org/dev/peps/pep-0397/>`_ allow scripts to
+       Script-execution features like ``PATHEXT`` and the :pep:`Python Launcher for
+       Windows <397>` allow scripts to
        be used in many cases, but not all.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -204,9 +204,9 @@ Glossary
     Version Specifier
 
        The version component of a :term:`Requirement Specifier`. For example,
-       the ">=1.3" portion of "foo>=1.3".  :ref:`PEP440 <pypa:PEP440s>` contains
-       a `full specification
-       <https://www.python.org/dev/peps/pep-0440/#version-specifiers>`_ of the
+       the ">=1.3" portion of "foo>=1.3".  :pep:`440` contains
+       a :pep:`full specification
+       <440#version-specifiers>` of the
        specifiers that Python packaging currently supports.  Support for PEP440
        was implemented in :ref:`setuptools` v8.0 and :ref:`pip` v6.0.
 
@@ -219,7 +219,7 @@ Glossary
 
     Wheel
 
-        A :term:`Built Distribution` format introduced by :ref:`pypa:PEP427s`,
+        A :term:`Built Distribution` format introduced by :pep:`427`,
         which is intended to replace the :term:`Egg` format.  Wheel is currently
         supported by :ref:`pip`.
 

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -172,8 +172,8 @@ The most common usage of :ref:`pip` is to install from the :term:`Python Package
 Index <Python Package Index (PyPI)>` using a :term:`requirement specifier
 <Requirement Specifier>`. Generally speaking, a requirement specifier is
 composed of a project name followed by an optional :term:`version specifier
-<Version Specifier>`.  :ref:`PEP440 <pypa:PEP440s>` contains a `full
-specification <https://www.python.org/dev/peps/pep-0440/#version-specifiers>`_
+<Version Specifier>`.  :pep:`440` contains a :pep:`full
+specification <440#version-specifiers>`
 of the currently supported specifiers. Below are some examples.
 
 To install the latest version of "SomeProject":
@@ -197,9 +197,8 @@ To install greater than or equal to one version and less than another:
  pip install 'SomeProject>=1,<2'
 
 
-To install a version that's `"compatible"
-<https://www.python.org/dev/peps/pep-0440/#compatible-release>`_ with a certain
-version: [4]_
+To install a version that's :pep:`"compatible" <440#compatible-release>`
+with a certain version: [4]_
 
 ::
 
@@ -379,8 +378,8 @@ Install `setuptools extras`_.
        pre-installed, thereby making it an equal alternative to
        :ref:`virtualenv`.
 
-.. [4] The compatible release specifier was accepted in :ref:`PEP440
-       <pypa:PEP440s>` and support was released in :ref:`setuptools` v8.0 and
+.. [4] The compatible release specifier was accepted in :pep:`440`
+       and support was released in :ref:`setuptools` v8.0 and
        :ref:`pip` v6.0
 
 .. _pyvenv: http://docs.python.org/3.4/library/venv.html

--- a/source/pip_easy_install.rst
+++ b/source/pip_easy_install.rst
@@ -38,7 +38,7 @@ Here's a breakdown of the important differences between pip and easy_install now
 |List Installed Packages       |Yes (``pip list`` and ``pip       |No                             |
 |                              |freeze``)                         |                               |
 +------------------------------+----------------------------------+-------------------------------+
-|:ref:`PEP438 <pypa:PEP438s>`  |Yes                               |No                             |
+|:pep:`438`                    |Yes                               |No                             |
 |Support                       |                                  |                               |
 +------------------------------+----------------------------------+-------------------------------+
 |Installation format           |'Flat' packages with `egg-info`   | Encapsulated Egg format       |

--- a/source/wheel_egg.rst
+++ b/source/wheel_egg.rst
@@ -12,7 +12,7 @@ use case of needing an install artifact that doesn't require building or
 compilation, which can be costly in testing and production workflows.
 
 The :term:`Egg` format was introduced by :ref:`setuptools` in 2004, whereas the
-:term:`Wheel` format was introduced by :ref:`PEP427 <pypa:PEP427s>` in 2012.
+:term:`Wheel` format was introduced by :pep:`427` in 2012.
 
 :term:`Wheel` is currently considered the standard for :term:`built <Built
 Distribution>` and :term:`binary <Binary Distribution>` packaging for Python.
@@ -20,7 +20,7 @@ Distribution>` and :term:`binary <Binary Distribution>` packaging for Python.
 Here's a breakdown of the important differences between :term:`Wheel` and :term:`Egg`.
 
 
-* :term:`Wheel` has an :ref:`official PEP <pypa:PEP427s>`. :term:`Egg` did not.
+* :term:`Wheel` has an :pep:`official PEP <427>`. :term:`Egg` did not.
 
 * :term:`Wheel` is a :term:`distribution <Distribution Package>` format, i.e a packaging
   format. [1]_ :term:`Egg` was both a distribution format and a runtime
@@ -31,10 +31,10 @@ Here's a breakdown of the important differences between :term:`Wheel` and :term:
   compatible with Python 2 and 3, it's possible for a wheel to be "universal",
   similar to an :term:`sdist <Source Distribution (or "sdist")>`.
 
-* :term:`Wheel` uses :ref:`PEP376-compliant <pypa:PEP376s>` ``.dist-info``
+* :term:`Wheel` uses :pep:`PEP376-compliant <376>` ``.dist-info``
   directories. Egg used ``.egg-info``.
 
-* :term:`Wheel` has a :ref:`richer file naming convention <pypa:PEP425s>`. A single
+* :term:`Wheel` has a :pep:`richer file naming convention <425>`. A single
   wheel archive can indicate its compatibility with a number of Python language
   versions and implementations, ABIs, and system architectures.
 
@@ -48,5 +48,5 @@ Here's a breakdown of the important differences between :term:`Wheel` and :term:
 ----
 
 .. [1] Circumstantially, in some cases, wheels can be used as an importable
-       runtime format, although `this is not officially supported at this time
-       <http://www.python.org/dev/peps/pep-0427/#is-it-possible-to-import-python-code-directly-from-a-wheel-file>`_.
+       runtime format, although :pep:`this is not officially supported at this time
+       <427#is-it-possible-to-import-python-code-directly-from-a-wheel-file>`.


### PR DESCRIPTION
During the build process, several warnings appear about undefined labels linking to PEPs (via the PyPA intersphinx mapping). For example:

```
/Users/ddbeck/projects/python-packaging-user-guide/source/wheel_egg.rst:37: WARNING: undefined label: pypa:pep425s (if the link has no caption the label must precede a section header)
```

This pull request replaces the broken PyPA labels and hardcoded PEP URLs with `:pep:` inline text roles. After these changes, the build completes without any warnings or errors (at least for me).