### PR TITLE
Update distributing.rst "Development mode" section

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -553,7 +553,14 @@ requirements file like so::
 
 The first line says to install your project and any dependencies. The second
 line overrides the "bar" dependency, such that it's fulfilled from vcs, not
-PyPI.  For more on requirements files, see the :ref:`Requirements File
+PyPI.
+
+If, however, you want "bar" installed from a local directory in editable mode, the requirements file should look like this, with the local paths at the top of the file::
+
+  -e /path/to/project/bar
+  -e .
+
+Otherwise, the dependency will be fulfilled from PyPI, due to the installation order of the requirements file.  For more on requirements files, see the :ref:`Requirements File
 <pip:Requirements Files>` section in the pip docs.  For more on vcs installs,
 see the :ref:`VCS Support <pip:VCS Support>` section of the pip docs.
 


### PR DESCRIPTION
Installing project and dependencies in editable mode using local directories, not vcs, using current instructions does not work. The local directory is found, but then the dependency is overridden and fulfilled by PyPI. Changing the order of the editable mode dependencies (i.e. putting editable mode dependencies which reside in local directories at the top of the requirements file) fixes this problem.
