### PR TITLE
Fix broken URL

### DIFF
--- a/source/installing.rst
+++ b/source/installing.rst
@@ -60,7 +60,7 @@ Install pip, setuptools, and wheel
 * Otherwise:
 
  * Securely Download `get-pip.py
-   <https://raw.github.com/pypa/pip/master/contrib/get-pip.py>`_ [1]_
+   <https://bootstrap.pypa.io/get-pip.py>`_ [1]_
 
  * Run ``python get-pip.py``. [2]_  This will install or upgrade pip.
    Additionally, it will install :ref:`setuptools` and :ref:`wheel` if they're


### PR DESCRIPTION
In the installing.rst document the bullet point, "Securely Download get-pip.py" contains an out of date link. I've updated it to use https://bootstrap.pypa.io/get-pip.py rather then https://raw.github.com/pypa/pip/master/contrib/get-pip.py