### PR TITLE
Fix a Sphinx warning in specifications.rst

### DIFF
--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -91,7 +91,7 @@ The platform compatibility tagging model used for ``wheel`` distribution is
 defined in :pep:`425`.
 
 The scheme defined in that PEP is insufficient for public distribution
-of Linux wheel files (and *nix wheel files in general), so :pep:`513` was
+of Linux wheel files (and \*nix wheel files in general), so :pep:`513` was
 created to define the ``manylinux1`` tag.
 
 Recording Installed Distributions


### PR DESCRIPTION
    [...]/source/specifications.rst:93: WARNING: Inline emphasis start-string without end-string.