### PR TITLE
Capture difference that pip doesn't allow for install config details …

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -92,6 +92,13 @@ Glossary
         :term:`package <Distribution Package>` discovery and consumption.
 
 
+    Per Project Index
+
+        A private or other non-canonical :term:`Package Index` indicated by
+        a specific :term:`Project` as the index preferred or required to
+        resolve dependencies of that project.
+
+
     Project
 
         A library, framework, script, plugin, application, or collection of data

--- a/source/pip_easy_install.rst
+++ b/source/pip_easy_install.rst
@@ -60,6 +60,9 @@ Here's a breakdown of the important differences between pip and easy_install now
 |Exclude scripts during install|No                                |Yes                            |
 |                              |                                  |                               |
 +------------------------------+----------------------------------+-------------------------------+
+|per project index             |Only in virtualenv                |Yes, via setup.cfg             |
+|                              |                                  |                               |
++------------------------------+----------------------------------+-------------------------------+
 
 ----
 


### PR DESCRIPTION
…such as the package index to be supplied per project as it is for easy_install.

Am I right in that for someone to use pip to install dependencies for a package, one must specify some parameters to get the package index? For example, with `easy_install`, one can invoke:

```
easy_install .
```

in a project dir, and if that project specifies `easy_install.index-url = https://devpi.mygroup.org/` in setup.cfg, the installer will use that index. But in pip, to get equivalent behavior, one must supply the index URL in an environment variable or on the command line or in a system-wide config or in a virtualenv, but it's not possible to derive the preferred, relevant index URL from the context of the package (sdist or checkout)?
