### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/source/deployment.rst
+++ b/source/deployment.rst
@@ -74,7 +74,7 @@ Uninstalling the program leaves the Python installation of the user intact.
 
 A big advantage of pynsist is that the Windows packages can be built on Linux.
 There are several examples for different kinds of programs (console, GUI) in
-the `documentation <http://pynsist.readthedocs.org>`__. The tool is released
+the `documentation <https://pynsist.readthedocs.io>`__. The tool is released
 under the MIT-licence.
 
 Application Bundles

--- a/source/extensions.rst
+++ b/source/extensions.rst
@@ -156,7 +156,7 @@ wrapper modules up to date.
   modules. It still involves wrapping the interfaces by hand, however, so
   may not be a good choice for wrapping large APIs.
 
-* `cffi <http://cffi.readthedocs.org/>`__ is a project created by some of the PyPy
+* `cffi <https://cffi.readthedocs.io/>`__ is a project created by some of the PyPy
   developers to make it straightforward for developers that already know
   both Python and C to expose their C modules to Python applications. It
   also makes it relatively straightforward to wrap a C module based on its

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -249,7 +249,7 @@ current user, use the ``--user`` flag:
 
 
 For more information see the `User Installs
-<https://pip.readthedocs.org/en/latest/user_guide.html#user-installs>`_ section
+<https://pip.readthedocs.io/en/latest/user_guide.html#user-installs>`_ section
 from the pip docs.
 
 
@@ -384,4 +384,4 @@ Install `setuptools extras`_.
        :ref:`pip` v6.0
 
 .. _venv: https://docs.python.org/3/library/venv.html
-.. _setuptools extras: http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
+.. _setuptools extras: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -169,7 +169,7 @@ The new unreleased PyPI application which can be previewed at https://pypi.org/.
 wheel
 =====
 
-`Docs <http://wheel.readthedocs.io/en/latest/>`__ |
+`Docs <https://wheel.readthedocs.io/en/latest/>`__ |
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://bitbucket.org/pypa/wheel/issues?status=new&status=open>`__ |
 `Bitbucket <https://bitbucket.org/pypa/wheel>`__ |
@@ -259,7 +259,7 @@ activities with Python.
 Hashdist
 ========
 
-`Docs <http://hashdist.readthedocs.org/en/latest/>`__ |
+`Docs <https://hashdist.readthedocs.io/en/latest/>`__ |
 `Github <https://github.com/hashdist/hashdist/>`__
 
 Hashdist is a library for building non-root software distributions. Hashdist is
@@ -272,7 +272,7 @@ powerful hybrid of virtualenv and buildout.
 pex
 ===
 
-`Docs <http://pex.readthedocs.org/en/latest/>`__ |
+`Docs <https://pex.readthedocs.io/en/latest/>`__ |
 `Github <https://github.com/pantsbuild/pex/>`__ |
 `PyPI <https://pypi.python.org/pypi/pex>`__
 

--- a/source/mirrors.rst
+++ b/source/mirrors.rst
@@ -35,7 +35,7 @@ cached copies of :term:`packages <Distribution Package>`:
    those downloaded files instead of going to PyPI.
 2. A variation on the above which pre-builds the installation files for
    the requirements using `pip wheel
-   <http://pip.readthedocs.org/en/latest/reference/pip_wheel.html>`_::
+   <https://pip.readthedocs.io/en/latest/reference/pip_wheel.html>`_::
 
     $ pip wheel --wheel-dir=/tmp/wheelhouse SomeProject
     $ pip install --no-index --find-links=/tmp/wheelhouse SomeProject


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified. Some redirected to newer URL's so I've replaced them with their redirect targets.
