### PR TITLE
Update references to the setuptools docs

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -14,9 +14,10 @@ development as a whole.  For example, it does not provide guidance or tool
 recommendations for version control, documentation, or testing.
 
 For more reference material, see `Building and Distributing Packages
-<http://pythonhosted.org/setuptools/setuptools.html>`_ in the :ref:`setuptools`
-docs, but note that some advisory content there may be outdated. In the event of
-conflicts, prefer the advice in the Python Packaging User Guide.
+<https://setuptools.readthedocs.io/en/latest/setuptools.html>`_ in the
+:ref:`setuptools` docs, but note that some advisory content there may be
+outdated. In the event of conflicts, prefer the advice in the Python
+Packaging User Guide.
 
 .. contents:: Contents
    :local:
@@ -313,8 +314,8 @@ that should be copied into the package. The paths are interpreted as relative to
 the directory containing the package.
 
 For more information, see `Including Data Files
-<http://pythonhosted.org/setuptools/setuptools.html#including-data-files>`_ from
-the `setuptools docs <http://pythonhosted.org/setuptools/setuptools.html>`_.
+<https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files>`_
+from the `setuptools docs <https://setuptools.readthedocs.io>`_.
 
 
 .. _`Data Files`:
@@ -376,7 +377,7 @@ entry points that may be defined by your project or others that you depend on.
 
 For more information, see the section on `Dynamic Discovery of Services and
 Plugins
-<http://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
+<https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
 from the :ref:`setuptools` docs.
 
 The most commonly used entry point is "console_scripts" (see below).
@@ -395,15 +396,15 @@ console_scripts
   },
 
 Use "console_script" `entry points
-<http://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
+<https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
 to register your script interfaces. You can then let the toolchain handle the
 work of turning these interfaces into actual scripts [2]_.  The scripts will be
 generated during the install of your :term:`distribution <Distribution
 Package>`.
 
 For more information, see `Automatic Script Creation
-<http://pythonhosted.org/setuptools/setuptools.html#automatic-script-creation>`_
-from the `setuptools docs <http://pythonhosted.org/setuptools/setuptools.html>`_.
+<https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation>`_
+from the `setuptools docs <https://setuptools.readthedocs.io>`_.
 
 .. _`Choosing a versioning scheme`:
 
@@ -563,8 +564,8 @@ Lastly, if you don't want to install any dependencies at all, you can run::
 
 
 For more information, see the `Development Mode
-<http://pythonhosted.org/setuptools/setuptools.html#development-mode>`_ section
-of the `setuptools docs <http://pythonhosted.org/setuptools/setuptools.html>`_.
+<https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode>`_ section
+of the `setuptools docs <https://setuptools.readthedocs.io>`_.
 
 .. _`Packaging Your Project`:
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -48,8 +48,8 @@ Glossary
         A :term:`Built Distribution` format introduced by :ref:`setuptools`,
         which is being replaced by :term:`Wheel`.  For details, see `The
         Internal Structure of Python Eggs
-        <http://pythonhosted.org/setuptools/formats.html>`_ and `Python Eggs
-        <http://peak.telecommunity.com/DevCenter/PythonEggs>`_
+        <https://setuptools.readthedocs.io/en/latest/formats.html>`_ and
+        `Python Eggs <http://peak.telecommunity.com/DevCenter/PythonEggs>`_
 
     Extension Module
 
@@ -163,7 +163,7 @@ Glossary
        A format used by :ref:`pip` to install packages from a :term:`Package
        Index`. For an EBNF diagram of the format, see the
        `pkg_resources.Requirement
-       <https://pythonhosted.org/setuptools/pkg_resources.html#requirement-objects>`_
+       <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirement-objects>`_
        entry in the :ref:`setuptools` docs. For example, "foo>=1.3" is a
        requirement specifier, where "foo" is the project name, and the ">=1.3"
        portion is the :term:`Version Specifier`

--- a/source/installing.rst
+++ b/source/installing.rst
@@ -302,9 +302,9 @@ Installing from a local src tree
 
 
 Installing from local src in `Development Mode
-<http://pythonhosted.org/setuptools/setuptools.html#development-mode>`_, i.e. in
-such a way that the project appears to be installed, but yet is still editable
-from the src tree.
+<https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode>`_,
+i.e. in such a way that the project appears to be installed, but yet is
+still editable from the src tree.
 
 ::
 

--- a/source/multi_version_install.rst
+++ b/source/multi_version_install.rst
@@ -39,5 +39,5 @@ wrapper script or use ``python -c '<commmand>'`` to invoke the application's
 main entry point directly.
 
 Refer to the `pkg_resources documentation
-<http://pythonhosted.org/setuptools/pkg_resources.html#workingset-objects>`__
+<https://setuptools.readthedocs.io/en/latest/pkg_resources.html#workingset-objects>`__
 for more details.

--- a/source/pip_easy_install.rst
+++ b/source/pip_easy_install.rst
@@ -63,7 +63,7 @@ Here's a breakdown of the important differences between pip and easy_install now
 
 ----
 
-.. [1] http://pythonhosted.org/setuptools/easy_install.html#natural-script-launcher
+.. [1] https://setuptools.readthedocs.io/en/latest/easy_install.html#natural-script-launcher
 
 
 .. _pylauncher support: https://bitbucket.org/pypa/pylauncher

--- a/source/projects.rst
+++ b/source/projects.rst
@@ -99,7 +99,7 @@ This guide!
 setuptools
 ==========
 
-`Docs <http://pythonhosted.org/setuptools>`__ |
+`Docs <https://setuptools.readthedocs.io>`__ |
 `User list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Dev list <http://groups.google.com/group/pypa-dev>`__ |
 `Issues <https://bitbucket.org/pypa/setuptools/issues>`__ |


### PR DESCRIPTION
The setuptools docs appear to have moved, and the old location doesn't work (at least at this time). Update all references to them (using https, and after checking they're still up to date).