### PR TITLE
Add Description-Content-Type field

### DIFF
--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -55,8 +55,8 @@ It is legal to specify ``Provides-Extra:`` without referencing it in any
 Description-Content-Type
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-A string containing the format of the distribution's description, so that
-tools can intelligently render the description.
+A string stating the markup syntax (if any) used in the distribution's
+description, so that tools can intelligently render the description.
 
 Historically, PyPI supported descriptions in plain text and `reStructuredText
 (reST) <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html>`_,

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -133,7 +133,7 @@ If a ``Description-Content-Type`` is an unrecognized value, then the assumed
 content type is ``text/plain`` (Although PyPI will probably reject anything
 with an unrecognized value).
 
-If the ``Description-Content-Type` is ``text/markdown`` and ``variant`` is not
+If the ``Description-Content-Type`` is ``text/markdown`` and ``variant`` is not
 specified or is set to an unrecognized value, then the assumed ``variant`` is
 ``CommonMark``.
 

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -87,8 +87,10 @@ The ``type/subtype`` part has only a few legal values:
 - ``text/x-rst``
 - ``text/markdown``
 
-There is one required parameter called ``charset``, to specify whether the text
-is UTF-8, ASCII, etc.
+One parameter is called ``charset``; it can be used to specify whether the
+character set in use is UTF-8, ASCII, etc. If ``charset`` is not provided, then
+it is recommended that the implementation (e.g.: PyPI) treat the content as
+UTF-8.
 
 Other parameters might be specific to the chosen subtype. For example, for the
 ``markdown`` subtype, there is a ``variant`` parameter that allows specifying

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -94,10 +94,16 @@ UTF-8.
 
 Other parameters might be specific to the chosen subtype. For example, for the
 ``markdown`` subtype, there is a ``variant`` parameter that allows specifying
-the variant of Markdown in use, such as ``Original`` for `Gruber's original
-Markdown syntax <https://tools.ietf.org/html/rfc7763#section-6.1.4>`_ or
-``GFM`` for `GitHub Flavored Markdown (GFM)
-<https://tools.ietf.org/html/rfc7764#section-3.2>`_.
+the variant of Markdown in use, such as:
+
+- ``CommonMark`` for `CommonMark`
+  <https://tools.ietf.org/html/rfc7764#section-3.5>`_
+
+- ``GFM`` for `GitHub Flavored Markdown (GFM)
+  <https://tools.ietf.org/html/rfc7764#section-3.2>`_
+
+- ``Original`` for `Gruber's original Markdown syntax
+  <https://tools.ietf.org/html/rfc7763#section-6.1.4>`_
 
 Example::
 
@@ -109,11 +115,15 @@ Example::
 
 Example::
 
-    Description-Content-Type: text/markdown; charset=UTF-8; variant=Original
+    Description-Content-Type: text/markdown; charset=UTF-8; variant=CommonMark
 
 Example::
 
     Description-Content-Type: text/markdown; charset=UTF-8; variant=GFM
+
+Example::
+
+    Description-Content-Type: text/markdown; charset=UTF-8; variant=Original
 
 If a ``Description-Content-Type`` is not specified, then the assumed content type
 is ``text/x-rst; charset=UTF-8``.

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -105,9 +105,9 @@ the variant of Markdown in use, such as:
 - ``Original`` for `Gruber's original Markdown syntax
   <https://tools.ietf.org/html/rfc7763#section-6.1.4>`_
 
-If the subtype is ``markdown`` and no ``variant`` is specified, then the
-implementation (e.g.: PyPI) should assume that the ``variant`` is
-``CommonMark``.
+If the subtype is ``markdown`` and no ``variant`` is specified or the specfied
+``variant`` is not recognized, then the implementation (e.g.: PyPI) should
+assume that the ``variant`` is ``CommonMark``.
 
 Example::
 
@@ -129,8 +129,15 @@ Example::
 
     Description-Content-Type: text/markdown; charset=UTF-8; variant=Original
 
-If a ``Description-Content-Type`` is not specified, then the assumed content type
-is ``text/x-rst; charset=UTF-8``.
+If a ``Description-Content-Type`` is not specified or it's set to an
+unrecognized value, then the assumed content type is ``text/x-rst;
+charset=UTF-8``.
+
+If the ``charset`` is not specified or it's set to an unrecognized value, then
+the assumed ``charset`` is ``UTF-8``.
+
+If the subtype is ``markdown`` and ``variant`` is not specified or it's set to
+an unrecognized value, then the assumed ``variant`` is ``CommonMark``.
 
 
 Version Specifiers

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -21,7 +21,7 @@ The current core metadata file format, version 1.2, is specified in :pep:`345`.
 
 However, the version specifiers and environment markers sections of that PEP
 have been superceded as described below. In addition, metadata files are
-permitted to contain the following additional field:
+permitted to contain the following additional fields:
 
 Provides-Extra (multiple use)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,6 +51,70 @@ respectively.
 
 It is legal to specify ``Provides-Extra:`` without referencing it in any
 ``Requires-Dist:``.
+
+Description-Content-Type
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+A string containing the format of the distribution's description, so that tools
+can intelligently render the description. Historically, distribution
+descriptions in plain text and in `reStructuredText (reST)
+<http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html>`_ have
+been supported and PyPI knows how to render reST into HTML. It is very common
+for distribution authors to write their description in `Markdown
+<https://daringfireball.net/projects/markdown/>`_ (`RFC 7763
+<https://tools.ietf.org/html/rfc7763>`_). Distribution authors commonly use
+Markdown probably because that's the markup language that they are most
+familiar with, but PyPI historically didn't know the format of the description
+and thus could not know to render a description as Markdown. This results in
+PyPI having many packages where the description is rendered in a very ugly way,
+because the description was written in Markdown, but PyPI is rendering it as
+reST. This field allows the distribution author to specify the format of their
+description and thus opens up the possibility for PyPI and other tools to be
+able to render Markdown and other formats.
+
+The format of this field is same as the ``Content-Type`` header in HTTP (e.g.:
+`RFC 1341 <https://www.w3.org/Protocols/rfc1341/4_Content-Type.html>`_).
+Briefly, this means that it has a ``type/subtype`` part and then it can
+optionally have a number of parameters:
+
+Format::
+
+    Description-Content-Type: <type>/<subtype>; charset=<charset>[; <param_name>=<param value> ...]
+
+The ``type/subtype`` part has only a few legal values:
+
+- ``text/plain``
+- ``text/x-rst``
+- ``text/markdown``
+
+There is one required parameter called ``charset``, to specify whether the text
+is UTF-8, ASCII, etc.
+
+Other parameters might be specific to the chosen subtype. For example, for the
+``markdown`` subtype, there is a ``variant`` parameter that allows specifying
+the variant of Markdown in use, such as ``Original`` for `Gruber's original
+Markdown syntax <https://tools.ietf.org/html/rfc7763#section-6.1.4>`_ or
+``GFM`` for `GitHub Flavored Markdown (GFM)
+<https://tools.ietf.org/html/rfc7764#section-3.2>`_.
+
+Example::
+
+    Description-Content-Type: text/plain; charset=UTF-8
+
+Example::
+
+    Description-Content-Type: text/x-rst; charset=UTF-8
+
+Example::
+
+    Description-Content-Type: text/markdown; charset=UTF-8; variant=Original
+
+Example::
+
+    Description-Content-Type: text/markdown; charset=UTF-8; variant=GFM
+
+If a ``Description-Content-Type`` is not specified, then the assumed content type
+is ``text/x-rst; charset=UTF-8``.
 
 
 Version Specifiers

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -96,7 +96,7 @@ Other parameters might be specific to the chosen subtype. For example, for the
 ``markdown`` subtype, there is a ``variant`` parameter that allows specifying
 the variant of Markdown in use, such as:
 
-- ``CommonMark`` for `CommonMark`
+- ``CommonMark`` for `CommonMark
   <https://tools.ietf.org/html/rfc7764#section-3.5>`_
 
 - ``GFM`` for `GitHub Flavored Markdown (GFM)

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -105,6 +105,10 @@ the variant of Markdown in use, such as:
 - ``Original`` for `Gruber's original Markdown syntax
   <https://tools.ietf.org/html/rfc7763#section-6.1.4>`_
 
+If the subtype is ``markdown`` and no ``variant`` is specified, then the
+implementation (e.g.: PyPI) should assume that the ``variant`` is
+``CommonMark``.
+
 Example::
 
     Description-Content-Type: text/plain; charset=UTF-8

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -125,12 +125,17 @@ Example::
 
     Description-Content-Type: text/markdown; charset=UTF-8; variant=Original
 
-If a ``Description-Content-Type`` is not specified or it's set to an
-unrecognized value, then the assumed content type is ``text/x-rst;
-charset=UTF-8``.
+If a ``Description-Content-Type`` is not specified, then applications should
+attempt to render it as ``text/x-rst; charset=UTF-8`` and fall back to
+``text/plain`` if it is not valid rst.
 
-If the subtype is ``markdown`` and ``variant`` is not specified or is set to
-an unrecognized value, then the assumed ``variant`` is ``CommonMark``.
+If a ``Description-Content-Type`` is an unrecognized value, then the assumed
+content type is ``text/plain`` (Although PyPI will probably reject anything
+with an unrecognized value).
+
+If the ``Description-Content-Type` is ``text/markdown`` and ``variant`` is not
+specified or is set to an unrecognized value, then the assumed ``variant`` is
+``CommonMark``.
 
 
 Version Specifiers


### PR DESCRIPTION
This allows specifying the content type of the distribution's description (e.g.: `text/plain`, `text/x-rst`, `text/markdown`).

See https://github.com/msabramo/python-packaging-user-guide/blob/description-content-type/source/specifications.rst#description-content-type

Cc: @nicktimko, @ncoghlan, @dstufft, @jaraco, @xavfernandez 

Related:
- https://mail.python.org/pipermail/distutils-sig/2016-May/028689.html
- https://github.com/pypa/readme_renderer/pull/3
- https://github.com/pypa/setuptools/pull/708
