### PR TITLE
Fix order of setup.py arguments for upload command

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -816,7 +816,7 @@ There are two options:
 
    ::
 
-    python setup.py sdist bdist_wheel upload
+    python setup.py bdist_wheel sdist upload
 
    This approach is covered here due to it being mentioned in other guides, but it
    is not recommended as it may use a plaintext HTTP or unverified HTTPS connection


### PR DESCRIPTION
If sdist was invoked before bdist_wheel - upload first tries sdist upload
and some metadata on pypi will be missing (notable, Requires
Distributions section).

c.f.

```
$ python setup.py sdist bdist_wheel upload -r https://pypi.python.org/pypi
[...]
running upload
Submitting dist/Diofant-0.8.0a2.tar.gz to https://pypi.python.org/pypi
HTTP Error 400: This filename has previously been used, you should use a different version.
error: HTTP Error 400: This filename has previously been used, you should use a different version.
```

vs
```
$ python setup.py bdist_wheel sdist upload -r https://pypi.python.org/pypi
[...]
running upload
Submitting /home/sk/src/diofant/dist/Diofant-0.8.0a2-py3-none-any.whl to https://pypi.python.org/pypi
HTTP Error 400: This filename has previously been used, you should use a different version.
error: HTTP Error 400: This filename has previously been used, you should use a different version.
```

Not sure if it's not a bug for setuptools, but it works in this way for recent setuptools too (checked with 25.1.1).
