### PR TITLE
Minor wording change for clarity

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -7,7 +7,7 @@ Packaging and Distributing Projects
 
 This section covers the basics of how to configure, package and distribute your
 own Python projects.  It assumes that you are already familiar with the contents
-of the :doc:`installing`.
+of the :doc:`installing` page.
 
 The section does *not* aim to cover best practices for Python project
 development as a whole.  For example, it does not provide guidance or tool


### PR DESCRIPTION
Right now the sentence as it renders on the webpage is missing a word:
![image](https://cloud.githubusercontent.com/assets/7017045/17422638/b074aecc-5a68-11e6-8cfa-ebf99a6b9a01.png)

I simply added the word "page" to complete the sentence. 