### PR TITLE
Note that download_url should not be used

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -197,6 +197,12 @@ url
 
 Give a homepage url for your project.
 
+.. note::
+
+  :ref:`setuptools` also documents a field `download_url`, however this is
+  not generally used.  Your packages should rather be uploaded directly to
+  :term:`PyPI <Python Package Index (PyPI)>`.
+
 
 author
 ~~~~~~


### PR DESCRIPTION
I used a lot of time barking up that tree, only to find out it's not meant to be set.
Primarily because the python setuptools docs contain it.

Some background info in https://github.com/pypa/setuptools_scm/issues/95
