### PR TITLE
Correct the example for keywords

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -258,9 +258,9 @@ keywords
 
 ::
 
-  keywords='sample setuptools development',
+  keywords=['sample', 'setuptools', 'development'],
 
-List keywords that describe your project.
+List of keywords that describe your project.
 
 
 packages


### PR DESCRIPTION
This PR changes the example for the `keywords` argument to include a `list` of keywords, not a space-separated string of keywords.

From my recent experience, [using](https://github.com/honzajavorek/redis-collections/blob/a5d4fe121d6ddeb323ba2a09ed5ca75f0d99a9f2/setup.py#L54) a space-separated list [results](https://pypi.python.org/pypi/redis-collections/0.4.0) in each character being interpreted as a separate keyword. 
