### PR TITLE
Mention requirement of 'wheel' package for Universal Wheels

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -625,7 +625,13 @@ Universal Wheels
 extensions) and support Python 2 and 3. This is a wheel that can be installed
 anywhere by :ref:`pip`.
 
-To build a Universal Wheel:
+To build a Universal Wheel, first install the `wheel` package:
+
+::
+
+ pip install wheel
+
+Then create the "Universal Wheel" package.
 
 ::
 


### PR DESCRIPTION
Building "Universal Wheels" requires the "wheel" package to be installed. The manual doesn't mention this. This pull request fixes that.