### PR TITLE
Update warehouse link to pypi.org

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -161,7 +161,7 @@ Warehouse
 Dev irc:#pypa-dev
 
 
-The new unreleased PyPI application which can be previewed at https://warehouse.python.org/.
+The new unreleased PyPI application which can be previewed at https://pypi.org/.
 
 
 .. _wheel:


### PR DESCRIPTION
warehouse.python.org redirects to pypi.org, so let's update the links too.