### PR TITLE
Fix typo in distributing.rst

### DIFF
--- a/source/distributing.rst
+++ b/source/distributing.rst
@@ -707,7 +707,7 @@ on. For details on the naming of wheel files, see :pep:`425`
 
   :term:`PyPI <Python Package Index (PyPI)>` currently supports uploads of
   platform wheels for Windows, OS X, and the multi-distro ``manylinux1`` ABI.
-  Details of the latter are defined in :pep`513`.
+  Details of the latter are defined in :pep:`513`.
 
 
 .. _`Uploading your Project to PyPI`:


### PR DESCRIPTION
* Add missing colon to make PEP-link work