### PR TITLE
Fix link-breaking typo

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -22,7 +22,7 @@ tools.
 This guide is maintained on `GitHub`_ by the `Python Packaging Authority`_. We
 happily accept any :doc:`contributions and feedback <contribute>`. 😊
 
-.. _GitHub: https://github.com/pypa/python-packaging-user-guide>
+.. _GitHub: https://github.com/pypa/python-packaging-user-guide
 .. _Python Packaging Authority: https://pypa.io
 
 Get started


### PR DESCRIPTION
There appears to have been a copy-and-paste error that lead to a `>` being included at the end of the URL for the "This guide is maintained on GitHub" link on the main page.  This fixes that.