### PR TITLE
Format the README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,22 +1,13 @@
 Python Packaging User Guide
 ===========================
 
+http://packaging.python.org
+
 The "Python Packaging User Guide" (PyPUG) aims to be the authoritative resource on
 how to package and install distributions in Python using current tools.
 
-The guide is currently maintained by the "Python Packaging Authority" (PyPA).
-It was forked from the “Hitchhiker's Guide to Packaging” in March 2013, which was
-maintained by Tarek Ziadé.  Thank you Tarek for all your efforts in Python
-packaging.
-
 To follow the development of Python packaging, see the `Python
 Packaging Authority <https://www.pypa.io>`_.
-
-The html version of the Guide is currently available online at
-http://packaging.python.org.
-
-The Python Packaging User Guide is licensed under a Creative Commons
-Attribution-ShareAlike license: http://creativecommons.org/licenses/by-sa/3.0 .
 
 
 Code of Conduct
@@ -25,5 +16,19 @@ Code of Conduct
 Everyone interacting in the Python Packaging User Guide project's codebases,
 issue trackers, chat rooms, and mailing lists is expected to follow the
 `PyPA Code of Conduct`_.
+
+History
+-------
+
+This Guide was forked from the “Hitchhiker's Guide to Packaging” in March 2013, 
+which was maintained by Tarek Ziadé. Thank you Tarek for all your efforts in 
+Python packaging.
+
+License
+-------
+
+The Python Packaging User Guide is licensed under a Creative Commons
+Attribution-ShareAlike license: http://creativecommons.org/licenses/by-sa/3.0 .
+
 
 .. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/


### PR DESCRIPTION
* Move the historic acknowledgement and license statements to their own sections at the end
* Put the URL to the guide immediately after the heading
* The guide is maintained by PyPA doesn't need to be mentioned (it's under the pypa org)