### PR TITLE
Cover the PyPI migration in Tool Recommendations

### DIFF
--- a/source/guides/tool-recommendations.rst
+++ b/source/guides/tool-recommendations.rst
@@ -43,6 +43,71 @@ Packaging Tool Recommendations
   to :term:`PyPI <Python Package Index (PyPI)>`.
 
 
+Publishing Platform Recommendations
+===================================
+
+The original Python Package Index implementation (hosted at
+`https://pypi.python.org`_) is being phased out in favour of an
+updated implementation hosted at `https://pypi.org`_. Both
+interface share a common database backend and file store,
+allowing the latter to assume more default responsibilities
+as it becomes more capable.
+
+Users consistently using the latest versions of the recommended
+tools above with their default settings don't need to worry about
+this migration, but users running older versions, or not using the
+default settings, will need to update their configurations in line
+with the recommendations below.
+
+
+Publishing releases
+-------------------
+
+* ``pypi.org`` became the default upload platform in September 2016
+* uploads through ``pypi.python.org`` will be switched off on July 3, 2017
+* The default settings switched to ``pypi.org`` in the following versions:
+  * ``twine`` 1.8.0
+  * ``setuptools`` 27.0.0
+  * Python 3.4.6 (``distutils`` update)
+  * Python 3.5.3 (``distutils`` update)
+  * Python 3.6.0 (``distutils`` update)
+
+
+Browsing packages
+-----------------
+
+* ``pypi.python.org`` is currently still the default interface for browsing packages
+  (used in links from other PyPA documentation, etc) 
+* ``pypi.org`` is fully functional for purposes of browsing available packages, and
+  some users may choose to opt in to using it
+* ``pypi.org`` is expected to become the default recommended interface for browsing
+  once the limitations in the next two sections are addressed (at which point
+  ``pypi.python.org`` is also expected to become a CNAME for ``pypi.org``)
+
+
+Downloading packages
+--------------------
+
+* ``pypi.python.org`` is currently still the default host for downloading packages
+* ``pypi.org`` is fully functional for purposes of downloading packages, and some users
+  may choose to opt in to using it, but its current hosting setup isn't capable of
+  handling the full bandwidth requirements of being the default download source (even
+  after accounting for the Fastly CDN)
+* ``pypi.org`` is expected to become the default host for downloading packages once
+  it has been redeployed into an environment capable of handling the associated
+  network load
+
+
+Managing published packages and releases
+----------------------------------------
+
+* ``pypi.python.org`` provides an interface for logged in users to manage their
+  published packages and releases
+* ``pypi.org`` does not currently provide such an interface
+* The missing capabilities are being tracked as part of the
+  `Shut Down Legacy PyPI <https://github.com/pypa/warehouse/milestone/7>`_
+  milestone
+
 ----
 
 .. [1] There are some cases where you might choose to use ``easy_install`` (from


### PR DESCRIPTION
During the migration from the legacy PyPI implementation
to Warehouse, `pypi.python.org` and `pypi.org` are
essentially alternative tools for the tasks of publishing,
browsing, downloading and managing packages.

This adds them to the Tool Recommendations page, so
folks have a single place to check to be informed of the
current recommendations, rather than having to try to
keep up with any announcements made at the time the
recommendations change.