### PR TITLE
Add trailing "/" to testpypi url

### DIFF
--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -88,6 +88,6 @@ with ``https://test.pypi.org/legacy/``, for example:
         testpypi
 
     [testpypi]
-    repository: https://test.pypi.org/legacy
+    repository: https://test.pypi.org/legacy/
     username: your testpypi username
     password: your testpypi password


### PR DESCRIPTION
The trailing `/` is important, as I found out in https://github.com/takluyver/flit/issues/122

Without the trailing `/`:

`~/.pypirc` file:
```
[testpypi]
repository = https://test.pypi.org/legacy
```

output:
```
$ twine upload -r testpypi dist/*
Uploading distributions to https://test.pypi.org/legacy
Uploading cherry_picker-0.0.3.post3-py3-none-any.whl
RedirectDetected: "https://test.pypi.org/legacy" attempted to redirect to "https://test.pypi.org/legacy/" during upload. Aborting... 
```

With the trailing `/`:

`~/.pypirc` file:
```
[testpypi]
repository = https://test.pypi.org/legacy/
```

output:
```
$ twine upload -r testpypi dist/*
Uploading distributions to https://test.pypi.org/legacy/
Uploading cherry_picker-0.0.3.post3-py3-none-any.whl
Uploading cherry_picker-0.0.3.post3.tar.gz                                     
```