### PR TITLE
encourage RST checking with readme_renderer

### DIFF
--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -809,6 +809,14 @@ distribution file(s) to upload.
   use a plaintext HTTP or unverified HTTPS connection on some Python versions,
   allowing your username and password to be intercepted during transmission.
 
+.. tip:: The reStructuredText parser used on PyPI is **not** Sphinx!
+  Furthermore, to ensure safety of all users, certain kinds of URLs and
+  directives are forbidden or stripped out (e.g., the ``.. raw::``
+  directive). **Before** trying to upload your distribution, you should check
+  to see if your brief / long descriptions provided in ``setup.py`` are valid.
+  You can do this by following the instructions for the
+  `pypa/readme_renderer <https://github.com/pypa/readme_renderer>`_ tool.
+
 Create an account
 -----------------
 


### PR DESCRIPTION
`python setup.py check --restructuredtext` did not report any errors, but `readme_renderer` explained effectively and concisely that `.. raw::` directives are not allowed.

1. I didn't know what to do for the admonition.  I think it's in the right section, but there was already a `note` and a `warning`, and the `pypa_theme` doesn't seem to stylize `tip` or `danger` (sphinx only?).
    - I could also make it a definition list under `**Tip**`?
2. Happy to change any and all verbiage.  I just feel like linking to this tool directly will save a lot of people time, and reduce burden on PyPI from people who are releasing versions just to try and get the long description to show up.
    - I'll confess this was me, but internet trolling seems to reveal it's not uncommon.  I can't use `testpypi` for some reason, so I didn't really have any options.
    - Then I happened upon this magical tool, and it told me exactly why I couldn't use it.  TBH I'm surprised GitHub even let my `.. raw:: html` through...
3. I specifically said "not Sphinx" because I think that's what most people assume it would be.
    - Should I link to Sphinx?
    - Should I state that it is the (golden standard) docutils parser?  (is that even correct)?

Let me know if you think this is worth including, but the verbiage should change!