### PR TITLE
Add a specification of the entry_points.txt file

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -506,6 +506,7 @@ Example::
 
 The label is a free text limited to 32 signs.
 
+.. _metadata_provides_extra:
 
 Provides-Extra (optional, multiple use)
 =======================================

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -22,7 +22,7 @@ Data model
 
 Conceptually, an entry point is defined by three required properties:
 
-The **group** an entry point belongs to indicates what sort of object it
+The **group** that an entry point belongs to indicates what sort of object it
 provides. For instance, the group ``console_scripts`` is for entry points
 referring to functions which can be used as a command, while
 ``pygments.styles`` is the group for classes defining pygments styles.

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -43,7 +43,8 @@ Conceptually, an entry point is defined by three required properties:
   point names should be unique. If different distributions provide the same
   name, the consumer decides how to handle such conflicts. The name may contain
   any characters except ``=``, but it cannot start or end with any whitespace
-  character, or start with ``[``.
+  character, or start with ``[``. For new entry points, it is recommended to
+  use only letters, numbers, underscores, dashes and dots (regex ``[\w-.]+``).
 
 - The **object reference** points to a Python object. It is either in the form
   ``importable.module``, or ``importable.module:object.attr``. Each of the parts

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -14,8 +14,13 @@ example:
   installed packages. For more about this, see
   :doc:`/guides/creating-and-discovering-plugins`.
 
-Entry points were developed as part of setuptools. This document aims to
-describe the mechanism that is already a de-facto standard.
+The entry point file format was originally developed to allow packages built
+with setuptools to provide integration point metadata that would be read at
+runtime with ``pkg_resources``. It is now defined as a PyPA interoperability
+specification in order to allow build tools other than setuptools to publish
+``pkg_resources`` compatible entry point metadata, and runtime libraries other
+than ``pkg_resources`` to portably read published entry point metadata
+(potentially with different caching and conflict resolution strategies).
 
 Data model
 ==========

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -26,7 +26,9 @@ Conceptually, an entry point is defined by three required properties:
   provides. For instance, the group ``console_scripts`` is for entry points
   referring to functions which can be used as a command, while
   ``pygments.styles`` is the group for classes defining pygments styles.
-  The consumer typically defines the expected interface.
+  The consumer typically defines the expected interface. To avoid clashes,
+  consumers defining a new group should use names starting with a PyPI name
+  owned by the consumer project, followed by ``.``.
 
 - The **name** identifies this entry point within its group. The precise meaning
   of this is up to the consumer. For console scripts, the name of the entry point

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -33,13 +33,17 @@ Conceptually, an entry point is defined by three required properties:
   ``pygments.styles`` is the group for classes defining pygments styles.
   The consumer typically defines the expected interface. To avoid clashes,
   consumers defining a new group should use names starting with a PyPI name
-  owned by the consumer project, followed by ``.``.
+  owned by the consumer project, followed by ``.``. Group names must be one or
+  more groups of letters, numbers and underscores, separated by dots (regex
+  ``^\w+(\.\w+)*$``).
 
 - The **name** identifies this entry point within its group. The precise meaning
   of this is up to the consumer. For console scripts, the name of the entry point
   is the command that will be used to launch it. Within a distribution, entry
   point names should be unique. If different distributions provide the same
-  name, the consumer decides how to handle such conflicts.
+  name, the consumer decides how to handle such conflicts. The name may contain
+  any characters except ``=``, but it cannot start or end with any whitespace
+  character, or start with ``[``.
 
 - The **object reference** points to a Python object. It is either in the form
   ``importable.module``, or ``importable.module:object.attr``. Each of the parts

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -147,3 +147,7 @@ Install tools are expected to set up wrappers for both ``console_scripts`` and
 ``gui_scripts`` in the scripts directory of the install scheme. They are not
 responsible for putting this directory in the ``PATH`` environment variable
 which defines where command-line tools are found.
+
+As files are created from the names, and some filesystems are case-insensitive,
+packages should avoid using names in these groups which differ only in case.
+The behaviour of install tools when names differ only in case is undefined.

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -1,0 +1,95 @@
+==========================
+Entry points specification
+==========================
+
+*Entry points* are a mechanism for an installed distribution to advertise
+components it provides to be discovered and used by other code. For
+example:
+
+- Distributions can specify ``console_scripts`` entry points, each referring to
+  a function. When *pip* installs the distribution, it will create a
+  command-line wrapper for each entry point.
+- Applications can use entry points to load plugins; e.g. Pygments (a syntax
+  highlighting tool) can use additional lexers and styles from separately
+  installed packages. For more about this, see
+  :doc:`/guides/creating-and-discovering-plugins`.
+
+Entry points were developed as part of setuptools. This document aims to
+describe the mechanism that is already a de-facto standard.
+
+Data model
+==========
+
+Conceptually, an entry point is defined by three required properties:
+
+The **group** an entry point belongs to indicates what sort of object it
+provides. For instance, the group ``console_scripts`` is for entry points
+referring to functions which can be used as a command, while
+``pygments.styles`` is the group for classes defining pygments styles.
+The consumer typically defines the expected interface.
+
+The **name** identifies this entry point within its group. The precise meaning
+of this is up to the consumer. For console scripts, the name of the entry point
+is the command that will be used to launch it.
+
+The **object path** points to a Python object. It is either in the form
+``importable.module``, or ``importable.module:object.attr``. Each of the parts
+delimited by dots and the colon is a valid Python identifier.
+It is intended to be looked up like this::
+
+    import importlib
+    if ':' in object_path:
+        modname, attrs = object_path.split(':')
+        obj = importlib.import_module(object_path)
+        for attr in attrs.split('.'):
+            obj = getattr(obj, attr)
+    else:
+        obj = importlib.import_module(object_path)
+
+.. note::
+   Some tools call this kind of object path by itself an 'entry point', for want
+   of a better term, especially where it points to a function to launch a
+   program.
+
+There is also an optional piece property: the **extras** are a set of strings
+identifying optional features of the distribution providing the entry point.
+If these are specified, the entry point requires the dependencies of those
+'extras'. See the metadata field :ref:`metadata_provides_extra`.
+
+File format
+===========
+
+Entry points are defined in a file called ``entry_points.txt`` in the
+``*.dist-info`` directory of the distribution. This is the directory described
+in :pep:`376` for installed distributions, and in :pep:`427` for wheels.
+The file uses the UTF-8 character encoding.
+
+The file contents are in INI format, as read by Python's :mod:`configparser`
+module. However, configparser treats names as case-insensitive by default,
+whereas entry point names are case sensitive. A case-sensitive config parser
+can be made like this::
+
+    import configparser
+
+    class CaseSensitiveConfigParser(configparser.ConfigParser):
+        optionxform = staticmethod(str)
+
+The entry points file always uses ``=`` to delimit names from values (whereas
+configparser also allows using ``:``).
+
+The sections of the config file represent entry point groups, the names are
+names, and the values encode both the object path and the optional extras.
+If extras are used, they are a comma-separated list inside square brackets.
+There may be zero, one or multiple spaces between the object name and the
+opening square bracket.
+
+For example::
+  
+    [console_scripts]
+    foo = foomod:main
+    # One which depends on extras:
+    foobar = foomod:main_bar [bar,baz]
+    
+    # pytest plugins refer to a module, so there is no ':obj'
+    [pytest11]
+    nbval = nbval.plugin

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -107,3 +107,34 @@ For example::
     # pytest plugins refer to a module, so there is no ':obj'
     [pytest11]
     nbval = nbval.plugin
+
+Use for scripts
+===============
+
+Two groups of entry points have special significant in packaging:
+``console_scripts`` and ``gui_scripts``. In both groups, the name of the entry
+point should be usable as a command in a system shell after the package is
+installed. The object reference points to a function which will be called with
+no arguments when this command is run. The function may return an integer to be
+used as a process exit code, and returning ``None`` is equivalent to returning
+``0``.
+
+For instance, the entry point ``mycmd = mymod:main`` would create a command
+``mycmd`` launching a script like this::
+
+    import sys
+    from mymod import main
+    sys.exit(main())
+
+The difference between ``console_scripts`` and ``gui_scripts`` only affects
+Windows systems. ``console_scripts`` are wrapped in a console executable,
+so they are attached to a console and can use ``sys.stdin``, ``sys.stdout`` and
+``sys.stderr`` for input and output. ``gui_scripts`` are wrapped in a GUI
+executable, so they can be started without a console, but cannot use standard
+streams unless application code redirects them. Other platforms do not have the
+same distinction.
+
+Install tools are expected to set up wrappers for both ``console_scripts`` and
+``gui_scripts`` in the scripts directory of the install scheme. They are not
+responsible for putting this directory in the ``PATH`` environment variable
+which defines where command-line tools are found.

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -56,6 +56,12 @@ identifying optional features of the distribution providing the entry point.
 If these are specified, the entry point requires the dependencies of those
 'extras'. See the metadata field :ref:`metadata_provides_extra`.
 
+The precise functionality of entry points with extras is tied to setuptools'
+model of adding ``.egg`` directories to ``sys.path`` at runtime. Other
+installation mechanisms (such as pip and virtualenv) work differently. Packages
+declaring entry points should not assume that extras have any particular effect
+on the environment of the code using the entry points.
+
 File format
 ===========
 

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -32,7 +32,9 @@ Conceptually, an entry point is defined by three required properties:
 
 - The **name** identifies this entry point within its group. The precise meaning
   of this is up to the consumer. For console scripts, the name of the entry point
-  is the command that will be used to launch it.
+  is the command that will be used to launch it. Within a distribution, entry
+  point names should be unique. If different distributions provide the same
+  name, the consumer decides how to handle that.
 
 - The **object reference** points to a Python object. It is either in the form
   ``importable.module``, or ``importable.module:object.attr``. Each of the parts
@@ -40,13 +42,11 @@ Conceptually, an entry point is defined by three required properties:
   It is intended to be looked up like this::
 
     import importlib
-    if ':' in object_ref:
-        modname, attrs = object_ref.split(':')
-        obj = importlib.import_module(object_ref)
-        for attr in attrs.split('.'):
+    modname, qualname_separator, qualname = object_ref.partition(':')
+    obj = importlib.import_module(modname)
+    if qualname_separator:
+        for attr in qualname.split('.'):
             obj = getattr(obj, attr)
-    else:
-        obj = importlib.import_module(object_ref)
 
 .. note::
    Some tools call this kind of object reference by itself an 'entry point', for
@@ -92,7 +92,8 @@ If extras are used, they are a comma-separated list inside square brackets.
 Within a value, readers must accept and ignore spaces (including multiple
 consecutive spaces) before or after the colon, between the object reference and
 the left square bracket, between the extra names and the square brackets and
-colons delimiting them, and after the right square bracket.
+colons delimiting them, and after the right square bracket. The syntax for
+extras is formally specified as part of :pep:`508` (as ``extras``).
 For tools writing the file, it is recommended only to insert a space between the
 object reference and the left square bracket.
 

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -39,7 +39,7 @@ Conceptually, an entry point is defined by three required properties:
   of this is up to the consumer. For console scripts, the name of the entry point
   is the command that will be used to launch it. Within a distribution, entry
   point names should be unique. If different distributions provide the same
-  name, the consumer decides how to handle that.
+  name, the consumer decides how to handle such conflicts.
 
 - The **object reference** points to a Python object. It is either in the form
   ``importable.module``, or ``importable.module:object.attr``. Each of the parts

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -7,8 +7,8 @@ components it provides to be discovered and used by other code. For
 example:
 
 - Distributions can specify ``console_scripts`` entry points, each referring to
-  a function. When *pip* installs the distribution, it will create a
-  command-line wrapper for each entry point.
+  a function. When *pip* (or another console_scripts aware installer) installs
+  the distribution, it will create a command-line wrapper for each entry point.
 - Applications can use entry points to load plugins; e.g. Pygments (a syntax
   highlighting tool) can use additional lexers and styles from separately
   installed packages. For more about this, see

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -22,33 +22,33 @@ Data model
 
 Conceptually, an entry point is defined by three required properties:
 
-The **group** that an entry point belongs to indicates what sort of object it
-provides. For instance, the group ``console_scripts`` is for entry points
-referring to functions which can be used as a command, while
-``pygments.styles`` is the group for classes defining pygments styles.
-The consumer typically defines the expected interface.
+- The **group** that an entry point belongs to indicates what sort of object it
+  provides. For instance, the group ``console_scripts`` is for entry points
+  referring to functions which can be used as a command, while
+  ``pygments.styles`` is the group for classes defining pygments styles.
+  The consumer typically defines the expected interface.
 
-The **name** identifies this entry point within its group. The precise meaning
-of this is up to the consumer. For console scripts, the name of the entry point
-is the command that will be used to launch it.
+- The **name** identifies this entry point within its group. The precise meaning
+  of this is up to the consumer. For console scripts, the name of the entry point
+  is the command that will be used to launch it.
 
-The **object path** points to a Python object. It is either in the form
-``importable.module``, or ``importable.module:object.attr``. Each of the parts
-delimited by dots and the colon is a valid Python identifier.
-It is intended to be looked up like this::
+- The **object reference** points to a Python object. It is either in the form
+  ``importable.module``, or ``importable.module:object.attr``. Each of the parts
+  delimited by dots and the colon is a valid Python identifier.
+  It is intended to be looked up like this::
 
     import importlib
-    if ':' in object_path:
-        modname, attrs = object_path.split(':')
-        obj = importlib.import_module(object_path)
+    if ':' in object_ref:
+        modname, attrs = object_ref.split(':')
+        obj = importlib.import_module(object_ref)
         for attr in attrs.split('.'):
             obj = getattr(obj, attr)
     else:
-        obj = importlib.import_module(object_path)
+        obj = importlib.import_module(object_ref)
 
 .. note::
-   Some tools call this kind of object path by itself an 'entry point', for want
-   of a better term, especially where it points to a function to launch a
+   Some tools call this kind of object reference by itself an 'entry point', for
+   want of a better term, especially where it points to a function to launch a
    program.
 
 There is also an optional property: the **extras** are a set of strings
@@ -84,15 +84,15 @@ The entry points file must always use ``=`` to delimit names from values
 (whereas configparser also allows using ``:``).
 
 The sections of the config file represent entry point groups, the names are
-names, and the values encode both the object path and the optional extras.
+names, and the values encode both the object reference and the optional extras.
 If extras are used, they are a comma-separated list inside square brackets.
 
 Within a value, readers must accept and ignore spaces (including multiple
-consecutive spaces) before or after the colon, between the object path and the
-left square bracket, between the extra names and the square brackets and colons
-delimiting them, and after the right square bracket.
+consecutive spaces) before or after the colon, between the object reference and
+the left square bracket, between the extra names and the square brackets and
+colons delimiting them, and after the right square bracket.
 For tools writing the file, it is recommended only to insert a space between the
-object path and the left square bracket.
+object reference and the left square bracket.
 
 For example::
   

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -80,8 +80,13 @@ The entry points file must always use ``=`` to delimit names from values
 The sections of the config file represent entry point groups, the names are
 names, and the values encode both the object path and the optional extras.
 If extras are used, they are a comma-separated list inside square brackets.
-There may be zero, one or multiple spaces between the object name and the
-opening square bracket.
+
+Within a value, readers must accept and ignore spaces (including multiple
+consecutive spaces) before or after the colon, between the object path and the
+left square bracket, between the extra names and the square brackets and colons
+delimiting them, and after the right square bracket.
+For tools writing the file, it is recommended only to insert a space between the
+object path and the left square bracket.
 
 For example::
   

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -51,7 +51,7 @@ It is intended to be looked up like this::
    of a better term, especially where it points to a function to launch a
    program.
 
-There is also an optional piece property: the **extras** are a set of strings
+There is also an optional property: the **extras** are a set of strings
 identifying optional features of the distribution providing the entry point.
 If these are specified, the entry point requires the dependencies of those
 'extras'. See the metadata field :ref:`metadata_provides_extra`.
@@ -74,8 +74,8 @@ can be made like this::
     class CaseSensitiveConfigParser(configparser.ConfigParser):
         optionxform = staticmethod(str)
 
-The entry points file always uses ``=`` to delimit names from values (whereas
-configparser also allows using ``:``).
+The entry points file must always use ``=`` to delimit names from values
+(whereas configparser also allows using ``:``).
 
 The sections of the config file represent entry point groups, the names are
 names, and the values encode both the object path and the optional extras.

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -68,11 +68,11 @@ identifying optional features of the distribution providing the entry point.
 If these are specified, the entry point requires the dependencies of those
 'extras'. See the metadata field :ref:`metadata_provides_extra`.
 
-The precise functionality of entry points with extras is tied to setuptools'
-model of adding ``.egg`` directories to ``sys.path`` at runtime. Other
-installation mechanisms (such as pip and virtualenv) work differently. Packages
-declaring entry points should not assume that extras have any particular effect
-on the environment of the code using the entry points.
+Using extras for an entry point is no longer recommended. Consumers should
+support parsing them from existing distributions, but may then ignore them.
+New publishing tools need not support specifying extras. The functionality of
+handling extras was tied to setuptools' model of managing 'egg' packages, but
+newer tools such as pip and virtualenv use a different model.
 
 File format
 ===========

--- a/source/specifications/entry-points.rst
+++ b/source/specifications/entry-points.rst
@@ -121,7 +121,7 @@ For example::
 Use for scripts
 ===============
 
-Two groups of entry points have special significant in packaging:
+Two groups of entry points have special significance in packaging:
 ``console_scripts`` and ``gui_scripts``. In both groups, the name of the entry
 point should be usable as a command in a system shell after the package is
 installed. The object reference points to a function which will be called with

--- a/source/specifications/index.rst
+++ b/source/specifications/index.rst
@@ -15,3 +15,4 @@ by the Python Packaging Authority.
    platform-compatibility-tags
    recording-installed-packages
    simple-repository-api
+   entry-points


### PR DESCRIPTION
As discussed on the distutils-sig mailing list, I would like entry points to be documented as an interoperable standard. I have a particular interest in this as I've written implementations of both creating entry points (flit) and loading them (entrypoints).

This is my attempt to document the entry points mechanism as it already exists, based on reading code and the [pkg_resources API docs](http://setuptools.readthedocs.io/en/latest/pkg_resources.html?highlight=pkg_resources#creating-and-parsing).