### PR TITLE
Add C:\Python36-x64 to AppVeyor sample

### DIFF
--- a/source/guides/appveyor-sample/appveyor.yml
+++ b/source/guides/appveyor-sample/appveyor.yml
@@ -17,6 +17,7 @@ environment:
     - PYTHON: "C:\\Python34-x64"
       DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
 
 install:
   # We need wheel installed to build wheels


### PR DESCRIPTION
AppVeyor now supports Python 3.6.3