### PR TITLE
Update single-sourcing-package-version.rst

### DIFF
--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -9,13 +9,10 @@ There are many techniques to maintain a single source of truth for the version
 number of your project:
 
 #.  Read the file in ``setup.py`` and parse the version with a regex. Example (
-    from `pip setup.py <https://github.com/pypa/pip/blob/1.5.6/setup.py#L33>`_)::
+    from `pip setup.py <https://github.com/pypa/pip/blob/master/setup.py#L12>`_)::
 
-        def read(*names, **kwargs):
-            with io.open(
-                os.path.join(os.path.dirname(__file__), *names),
-                encoding=kwargs.get("encoding", "utf8")
-            ) as fp:
+        def read(*parts):
+            with codecs.open(os.path.join(here, *parts), 'r') as fp:
                 return fp.read()
 
         def find_version(*file_paths):

--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -10,6 +10,8 @@ number of your project:
 
 #.  Read the file in ``setup.py`` and parse the version with a regex. Example (
     from `pip setup.py <https://github.com/pypa/pip/blob/master/setup.py#L12>`_)::
+    
+        here = os.path.abspath(os.path.dirname(__file__))
 
         def read(*parts):
             with codecs.open(os.path.join(here, *parts), 'r') as fp:


### PR DESCRIPTION
* Bump example link to master from antiquated 1.5.6 tag (we should at least bump it to the latest tag)
* Fix for read function to match with current state of pip example