### PR TITLE
wheel is now on GitHub

### DIFF
--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -180,8 +180,8 @@ wheel
 
 `Docs <https://wheel.readthedocs.io/en/latest/>`__ |
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
-`Issues <https://bitbucket.org/pypa/wheel/issues?status=new&status=open>`__ |
-`Bitbucket <https://bitbucket.org/pypa/wheel>`__ |
+`Issues <https://github.com/pypa/wheel/issues>`__ |
+`Bitbucket <https://github.com/pypa/wheel>`__ |
 `PyPI <https://pypi.python.org/pypi/wheel>`__ |
 User irc:#pypa  |
 Dev irc:#pypa-dev

--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -417,7 +417,7 @@ For more information see the distutils section on `Installing Additional Files
   "sdist")>`.  This is not true when installing from :term:`wheel`
   distributions. Wheels don't support absolute paths, and they end up being
   installed relative to "site-packages".  For discussion see `wheel Issue #92
-  <https://bitbucket.org/pypa/wheel/issue/92>`_.
+  <https://github.com/pypa/wheel/issues/92>`_.
 
 
 scripts


### PR DESCRIPTION
Now that wheel is on GitHub, I updated the links in the Project
Summaries.  I also found one link that pointed to the (now-removed)
issue tracker on BitBucket, and changed it to the corresponding issue
on GitHub.