### PR TITLE
Capitalize "Python" when describing the language.

### DIFF
--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -29,7 +29,7 @@ Supporting multiple hardware platforms
   For distributions with binary extensions, deployment is major headache.  Not only
   must the extensions be built on all the combinations of operating system and
   hardware platform, but they must also be tested, preferably on continuous
-  integration platforms.  The issues are similar to the "multiple python
+  integration platforms.  The issues are similar to the "multiple Python
   versions" section above, not sure whether this should be a separate section.
   Even on Windows x64, both the 32 bit and 64 bit versions of Python enjoy
   significant usage.

--- a/source/discussions/install-requires-vs-requirements.rst
+++ b/source/discussions/install-requires-vs-requirements.rst
@@ -68,7 +68,7 @@ just a list of :ref:`pip:pip install` arguments placed into a file.
 
 Whereas ``install_requires`` defines the dependencies for a single project,
 :ref:`Requirements Files <pip:Requirements Files>` are often used to define
-the requirements for a complete python environment.
+the requirements for a complete Python environment.
 
 Whereas ``install_requires`` requirements are minimal, requirements files
 often contain an exhaustive listing of pinned versions for the purpose of

--- a/source/discussions/wheel-vs-egg.rst
+++ b/source/discussions/wheel-vs-egg.rst
@@ -24,7 +24,7 @@ Here's a breakdown of the important differences between :term:`Wheel` and :term:
   installation format (if left zipped), and was designed to be importable.
 
 * :term:`Wheel` archives do not include .pyc files. Therefore, when the
-  distribution only contains python files (i.e. no compiled extensions), and is
+  distribution only contains Python files (i.e. no compiled extensions), and is
   compatible with Python 2 and 3, it's possible for a wheel to be "universal",
   similar to an :term:`sdist <Source Distribution (or "sdist")>`.
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -19,9 +19,9 @@ Glossary
         target system, to be installed. :term:`Wheel` is such a format, whereas
         distutil's :term:`Source Distribution <Source Distribution (or
         "sdist")>` is not, in that it requires a build step before it can be
-        installed.  This format does not imply that python files have to be
+        installed.  This format does not imply that Python files have to be
         precompiled (:term:`Wheel` intentionally does not include compiled
-        python files).
+        Python files).
 
 
     Distribution Package

--- a/source/guides/installing-scientific-packages.rst
+++ b/source/guides/installing-scientific-packages.rst
@@ -151,7 +151,7 @@ macOS, and Linux. Conda can be used to package up and distribute all kinds of
 packages, it is not limited to just Python packages.   It has full support 
 for native virtual environments. Conda makes environments first-class citizens, 
 making it easy to create independent environments even for C libraries. It is 
-written in Python, but is Python-agnostic. Conda manages python itself as a 
+written in Python, but is Python-agnostic. Conda manages Python itself as a 
 package, so that `conda update python` is possible, in contrast to pip, which only 
 manages Python packages. Conda is available in Anaconda and Miniconda 
 (an easy-to-install download with just Python and conda). 

--- a/source/guides/supporting-multiple-python-versions.rst
+++ b/source/guides/supporting-multiple-python-versions.rst
@@ -91,7 +91,7 @@ Tools for single-source Python packages
 `six <http://pythonhosted.org/six/>`_ is a tool developed by Benjamin Peterson
 for wrapping over the differences between Python 2 and Python 3. The six_
 package has enjoyed widespread use and may be regarded as a reliable way to
-write a single-source python module that can be use in both Python 2 and 3.
+write a single-source Python module that can be use in both Python 2 and 3.
 The six_ module can be used from as early as Python 2.5. A tool called
 `modernize <https://pypi.python.org/pypi/modernize>`_, developed by Armin
 Ronacher, can be used to automatically apply the code modifications provided

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -206,7 +206,7 @@ bento
 `Github <https://github.com/cournape/Bento>`__ |
 `PyPI <https://pypi.python.org/pypi/bento>`__
 
-Bento is a packaging tool solution for python software, targeted as an
+Bento is a packaging tool solution for Python software, targeted as an
 alternative to distutils, setuptools, distribute, etc....  Bento's philosophy is
 reproducibility, extensibility and simplicity (in that order).
 


### PR DESCRIPTION
Per the [style
guide](https://devguide.python.org/documenting/#capitalization).
Instances involving URLs, commands, etc. were not modified.