### PR TITLE
 Replace `~` with `$HOME` in guides, tutorials 

### DIFF
--- a/source/guides/installing-using-pip-and-virtualenv.rst
+++ b/source/guides/installing-using-pip-and-virtualenv.rst
@@ -55,7 +55,7 @@ Afterwards, you should have the newest pip installed in your user site:
 .. code-block:: bash
 
     python3 -m pip --version
-    pip 9.0.1 from ~/.local/lib/python3.6/site-packages (python 3.6)
+    pip 9.0.1 from $HOME/.local/lib/python3.6/site-packages (python 3.6)
 
 .. _python-pip: https://packages.debian.org/stable/python-pip
 

--- a/source/guides/installing-using-pip-and-virtualenv.rst
+++ b/source/guides/installing-using-pip-and-virtualenv.rst
@@ -41,7 +41,7 @@ Linux and macOS
 
 Debian and most other distributions include a `python-pip`_ package, if you
 want to use the Linux distribution-provided versions of pip see
-:doc:`/guides/installing-using-linux-tools`. 
+:doc:`/guides/installing-using-linux-tools`.
 
 You can also install pip yourself to ensure you have the latest version. It's
 recommended to use the system pip to bootstrap a user installation of pip:
@@ -102,7 +102,7 @@ virtualenv.
 
 On macOS and Linux:
 
-.. code-block:: bash 
+.. code-block:: bash
 
     python3 -m virtualenv env
 
@@ -287,7 +287,7 @@ wheel, or tar file) you can install it directly with pip:
 
 .. code-block:: bash
 
-    pip install requests-2.18.4.tar.gz 
+    pip install requests-2.18.4.tar.gz
 
 If you have a directory containing archives of multiple packages, you can tell
 pip to look for packages there and not to use the

--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -23,7 +23,7 @@ included with Python 3.4.6+, Python 3.5.3+, Python 3.6+, and 2.7.13+.
 In addition to ensuring you're on a new enough version of the tool for the
 tool's default to have switched, you must also make sure that you have not
 configured the tool to override its default upload URL. Typically this is
-configured in a file located at ``~/.pypirc``. If you see a file like:
+configured in a file located at ``$HOME/.pypirc``. If you see a file like:
 
 .. code::
 
@@ -40,10 +40,10 @@ configured in a file located at ``~/.pypirc``. If you see a file like:
 Then simply delete the line starting with ``repository`` and you will use
 your upload tool's default URL.
 
-If for some reason you're unable to upgrade the version of your tool to a
-version that defaults to using PyPI.org, then you may edit ``~/.pypirc`` and
-include the ``repository:`` line, but use the value
-``https://upload.pypi.org/legacy/`` instead:
+If for some reason you're unable to upgrade the version of your tool
+to a version that defaults to using PyPI.org, then you may edit
+``$HOME/.pypirc`` and include the ``repository:`` line, but use the
+value ``https://upload.pypi.org/legacy/`` instead:
 
 .. code::
 
@@ -76,7 +76,7 @@ uploading artifacts.
 Using TestPyPI
 --------------
 
-If you use TestPyPI, you must update your ``~/.pypirc`` to handle
+If you use TestPyPI, you must update your ``$HOME/.pypirc`` to handle
 TestPyPI's new location, by replacing ``https://testpypi.python.org/pypi``
 with ``https://test.pypi.org/legacy/``, for example:
 

--- a/source/guides/using-testpypi.rst
+++ b/source/guides/using-testpypi.rst
@@ -52,9 +52,9 @@ Setting up TestPyPI in pypirc
 -----------------------------
 
 If you want to avoid entering the TestPyPI url and your username and password
-you can configure TestPyPI in your ``~/.pypirc``.
+you can configure TestPyPI in your ``$HOME/.pypirc``.
 
-Create or modify ``~/.pypirc`` with the following:
+Create or modify ``$HOME/.pypirc`` with the following:
 
 .. code::
 

--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -840,7 +840,7 @@ can create an account
 `using the form on the PyPI website <https://pypi.python.org/pypi?%3Aaction=register_form>`_.
 
 .. Note:: If you want to avoid entering your username and password when
-  uploading, you can create a ``~/.pypirc`` file with your username and
+  uploading, you can create a ``$HOME/.pypirc`` file with your username and
   password:
 
   .. code-block:: text


### PR DESCRIPTION
Be more explicit to help users who aren't as familiar with the tilde. Inspired by an experience @lgh2 had, figuring out where `.pypirc` files live:

`<lghampton>` I think it was the `~/.pypirc` syntax that confused me, it wasn't clear to me that it referred to `$HOME` or something relative to the project path

I left out instances where the tilde was explicitly explained in the paragraph where it was used (`source/tutorials/managing-dependencies.rst`, and where the tilde appeared as part of sample terminal output.

I might be wrong in proposing this PR. I'm open to being told, for instance, that we need to use `~` for platform compatibility reasons, or for uniformity with other documentation. In that case I'd like for us to explicitly mention what it means, contextually, as in `source/tutorials/managing-dependencies.rst`:

> this will typically print ``~/.local`` (with ``~`` expanded to the absolute path to your home directory)

cc @jonparrott 