### PR TITLE
Fix code block inside note.

### DIFF
--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -61,7 +61,7 @@ please install the latest 3.x version from `python.org`_ or refer to the
 
     If you're using an enhanced shell like IPython or the Jupyter notebook, you
     can run system commands like those in this tutorial by prefacing them with
-    a ``!`` character::
+    a ``!`` character:
 
     .. code-block:: python
 


### PR DESCRIPTION
The double colon was causing the `..code-block` line to be interpreted
as part of the code itself and therefore displaying in the HTML.