### PR TITLE
Add information on how to view test packages 

### DIFF
--- a/source/guides/using-testpypi.rst
+++ b/source/guides/using-testpypi.rst
@@ -30,6 +30,14 @@ in the ``--repository-url`` flag
 
     $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
+The ``legacy`` in the URL above refers to the legacy API for PyPI, which may
+change as the Warehouse project progresses.
+
+You can see if your package has successfully uploaded by navigating to the URL
+``https://test.pypi.org/project/<sampleproject>`` where ``sampleproject`` is
+the name of your project that you uploaded. It may take a minute or two for
+your project to appear on the site.
+
 Using TestPyPI with pip
 -----------------------
 


### PR DESCRIPTION
This PR addresses part of [issue 422](https://github.com/pypa/python-packaging-user-guide/issues/422). 

This PR adds an explanation of the `legacy` in `test.pypi.org/legacy` and adds information on how to view your package on test.pypi.org once it has been uploaded. 

In the example of how to view the package, I use `sampleproject` as a placeholder for the project name, but I can change it if someone has an idea for a clearer name. 
