### PR TITLE
Core Metadata: Add example of multiple emails

### DIFF
--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -292,6 +292,11 @@ Example::
 
     Author-email: "C. Schultz" <cschultz@example.com>
 
+Per RFC-822, this field may contain multiple comma-separated e-mail
+addresses::
+
+    Author-email: cschultz@example.com, snoopy@peanuts.com
+
 
 Maintainer (optional)
 =====================
@@ -327,6 +332,11 @@ omitted if it is identical to ``Author-email``.
 Example::
 
     Maintainer-email: "C. Schultz" <cschultz@example.com>
+
+Per RFC-822, this field may contain multiple comma-separated e-mail
+addresses::
+
+    Maintainer-email: cschultz@example.com, snoopy@peanuts.com
 
 
 License (optional)


### PR DESCRIPTION
This is often asked for, has always been permitted by the spec, and is now accepted as valid by Warehouse (https://github.com/pypa/warehouse/pull/2904), so let's include an example here.