### PR TITLE
Issue #401: Consolidate PyPI migration info

### DIFF
--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -12,13 +12,24 @@ update to deal with the new location.
 This section covers how to migrate to the new PyPI.org for different tasks.
 
 
-Uploading
----------
+Publishing releases
+-------------------
+
+``pypi.org`` became the default upload platform in September 2016.
+
+Uploads through ``pypi.python.org`` were *switched off* on **July 3, 2017**.
 
 The recommended way to migrate to PyPI.org for uploading is to ensure that you
-are using a new enough version of your upload tool. Tools that support PyPI.org
-by default are twine v1.8.0+ (recommended tool), setuptools 27+, or the distutils
-included with Python 3.4.6+, Python 3.5.3+, Python 3.6+, and 2.7.13+.
+are using a new enough version of your upload tool.
+
+The default upload settings switched to ``pypi.org`` in the following versions:
+
+* ``twine`` 1.8.0
+* ``setuptools`` 27.0.0
+* Python 2.7.13 (``distutils`` update)
+* Python 3.4.6 (``distutils`` update)
+* Python 3.5.3 (``distutils`` update)
+* Python 3.6.0 (``distutils`` update)
 
 In addition to ensuring you're on a new enough version of the tool for the
 tool's default to have switched, you must also make sure that you have not
@@ -56,6 +67,9 @@ value ``https://upload.pypi.org/legacy/`` instead:
     username: your username
     password: your password
 
+(``legacy`` in this URL refers to the fact that this is the new server
+implementation's emulation of the legacy server implementation's upload API)
+
 
 Registering package names & metadata
 ------------------------------------
@@ -91,3 +105,53 @@ with ``https://test.pypi.org/legacy/``, for example:
     repository: https://test.pypi.org/legacy/
     username: your testpypi username
     password: your testpypi password
+
+
+Registering new user accounts
+-----------------------------
+
+In order to help mitigate spam attacks against PyPI, new user registration
+through ``pypi.python.org`` was *switched off* on **February 20, 2018**.
+
+
+Browsing packages
+-----------------
+
+``pypi.python.org`` is currently still the default interface for browsing packages
+(used in links from other PyPA documentation, etc).
+
+``pypi.org`` is fully functional for purposes of browsing available packages, and
+some users may choose to opt in to using it.
+
+``pypi.org`` is expected to become the default recommended interface for browsing
+once the limitations in the next two sections are addressed (at which point
+attempts to access ``pypi.python.org`` will automatically be redirected to
+``pypi.org``).
+
+
+Downloading packages
+--------------------
+
+``pypi.python.org`` is currently still the default host for downloading packages.
+
+``pypi.org`` is fully functional for purposes of downloading packages, and some users
+may choose to opt in to using it, but its current hosting setup isn't capable of
+handling the full bandwidth requirements of being the default download source (even
+after accounting for the Fastly CDN).
+
+``pypi.org`` is expected to become the default host for downloading packages once
+it has been redeployed into an environment capable of handling the associated
+network load.
+
+
+Managing published packages and releases
+----------------------------------------
+
+``pypi.python.org`` provides an interface for logged in users to manage their
+published packages and releases.
+
+``pypi.org`` does not currently provide such an interface.
+
+The missing capabilities are being tracked as part of the
+`Shut Down Legacy PyPI <https://github.com/pypa/warehouse/milestone/7>`_
+milestone.

--- a/source/guides/tool-recommendations.rst
+++ b/source/guides/tool-recommendations.rst
@@ -52,70 +52,8 @@ of an updated implementation hosted at `pypi.org <https://pypi.org>`_. Both
 interfaces share a common database backend and file store, allowing the latter
 to assume more default responsibilities as it becomes more capable.
 
-Users consistently using the latest versions of the recommended tools above
-with their default settings don't need to worry about this migration, but
-users running older versions, or not using the default settings, will need
-to update their configurations in line with the recommendations below.
-
-
-Publishing releases
--------------------
-
-``pypi.org`` became the default upload platform in September 2016.
-
-Uploads through ``pypi.python.org`` will be *switched off* on **July 3, 2017**.
-
-The default upload settings switched to ``pypi.org`` in the following versions:
-
-* ``twine`` 1.8.0
-* ``setuptools`` 27.0.0
-* Python 2.7.13 (``distutils`` update)
-* Python 3.4.6 (``distutils`` update)
-* Python 3.5.3 (``distutils`` update)
-* Python 3.6.0 (``distutils`` update)
-
-
-Browsing packages
------------------
-
-``pypi.python.org`` is currently still the default interface for browsing packages
-(used in links from other PyPA documentation, etc).
-
-``pypi.org`` is fully functional for purposes of browsing available packages, and
-some users may choose to opt in to using it.
-
-``pypi.org`` is expected to become the default recommended interface for browsing
-once the limitations in the next two sections are addressed (at which point
-attempts to access ``pypi.python.org`` will automatically be redirected to
-``pypi.org``).
-
-
-Downloading packages
---------------------
-
-``pypi.python.org`` is currently still the default host for downloading packages.
-
-``pypi.org`` is fully functional for purposes of downloading packages, and some users
-may choose to opt in to using it, but its current hosting setup isn't capable of
-handling the full bandwidth requirements of being the default download source (even
-after accounting for the Fastly CDN).
-
-``pypi.org`` is expected to become the default host for downloading packages once
-it has been redeployed into an environment capable of handling the associated
-network load.
-
-
-Managing published packages and releases
-----------------------------------------
-
-``pypi.python.org`` provides an interface for logged in users to manage their
-published packages and releases.
-
-``pypi.org`` does not currently provide such an interface.
-
-The missing capabilities are being tracked as part of the
-`Shut Down Legacy PyPI <https://github.com/pypa/warehouse/milestone/7>`_
-milestone.
+See :ref:`Migrating to PyPI.org` for more information on the current status of
+the migration, and the required settings for opting in to the migration early.
 
 ----
 


### PR DESCRIPTION
- continue to describe the migration on the recommendations
  page, but link to the migration page for details
- merge the info from the recommendations page into the
  migration page
- add a new section about user registration migrating due
  to a spam attack against the legacy service