### PR TITLE
Update PyPI links in distribution tutorial

### DIFF
--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -843,7 +843,7 @@ Create an account
 
 First, you need a :term:`PyPI <Python Package Index (PyPI)>` user account. You
 can create an account
-`using the form on the PyPI website <https://pypi.python.org/pypi?%3Aaction=register_form>`_.
+`using the form on the PyPI website <https://pypi.org/account/register/>`_.
 
 .. Note:: If you want to avoid entering your username and password when
   uploading, you can create a ``$HOME/.pypirc`` file with your username and

--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -819,10 +819,10 @@ distribution file(s) to upload.
   or the configuration in your ``setup.py`` file, you will need to rebuild
   these files again before you can distribute the changes to PyPI.
 
-.. note:: Before releasing on main PyPI repo, you might prefer training with
-  the `PyPI test site <https://testpypi.python.org/pypi>`_
-  which is cleaned on a semi regular basis. See :ref:`using-test-pypi`
-  on how to setup your configuration in order to use it.
+.. note:: Before releasing on main PyPI repo, you might prefer
+  training with the `PyPI test site <https://test.pypi.org/>`_ which
+  is cleaned on a semi regular basis. See :ref:`using-test-pypi` on
+  how to setup your configuration in order to use it.
 
 .. warning:: In other resources you may encounter references to using
   ``python setup.py register`` and ``python setup.py upload``. These methods


### PR DESCRIPTION
- Update PyPI user account registration link (Per https://status.python.org/incidents/mgjw1g5yjy5j PyPI , user account registration is now only allowed on pypi.org)
- Update Test PyPI link in distribution tutorial (Issue #401)