### PR TITLE
Document `project_urls` as an option to setup.py

### DIFF
--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -312,7 +312,7 @@ project_urls
   },
 
 List additional relevant URLs about your project. This is the place to link to
-bug trackers, source repositories, or links for supporting package development.
+bug trackers, source repositories, or where to support package development.
 The string of the key is the exact text that will be displayed on PyPI.
 
 

--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -305,10 +305,11 @@ project_urls
 ::
 
   project_urls={
-      'Bug Reports': 'https://github.com/pypa/sampleproject/issues',
+      'Documentation': 'https://packaging.python.org/tutorials/distributing-packages/',
       'Funding': 'https://donate.pypi.org',
       'Say Thanks!': 'http://saythanks.io/to/example',
       'Source': 'https://github.com/pypa/sampleproject/',
+      'Tracker': 'https://github.com/pypa/sampleproject/issues',
   },
 
 List additional relevant URLs about your project. This is the place to link to

--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -299,6 +299,23 @@ keywords
 List keywords that describe your project.
 
 
+project_urls
+~~~~~~~~~~~~
+
+::
+
+  project_urls={
+      'Bug Reports': 'https://github.com/pypa/sampleproject/issues',
+      'Funding': 'https://donate.pypi.org',
+      'Say Thanks!': 'http://saythanks.io/to/example',
+      'Source': 'https://github.com/pypa/sampleproject/',
+  },
+
+List additional relevant URLs about your project. This is the place to link to
+bug trackers, source repositories, or links for supporting package development.
+The string of the key is the exact text that will be displayed on PyPI.
+
+
 packages
 ~~~~~~~~
 


### PR DESCRIPTION
`project_urls` is an allowed option to `setup()` that provides a really nice
place for maintainers to add bug tracker or funding URLs. The hope is that by
documenting the usage, maintainers will be encouraged to add more useful URLs
to their setup.py.

This ticket comes by way of https://github.com/pypa/setuptools/issues/1276 and the corresponding PR in `sampleproject` has already been merged: https://github.com/pypa/sampleproject/pull/63