### PR TITLE
Fix 'installing packages' link in Packaging and Distributing Packages.

### DIFF
--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -6,7 +6,7 @@ Packaging and Distributing Projects
 
 This section covers the basics of how to configure, package and distribute your
 own Python projects.  It assumes that you are already familiar with the contents
-of the :doc:`installing` page.
+of the :doc:`installing-packages` page.
 
 The section does *not* aim to cover best practices for Python project
 development as a whole.  For example, it does not provide guidance or tool


### PR DESCRIPTION
The Packaging and Distributing Projects tutorial assumes familiarity
with the Installing Packages tutorial, but links instead to the pip
Installation tutorial. This commit replaces the pip link with the link
to the Installing Packages tutorial.