### PR TITLE
Add README guide

### DIFF
--- a/source/guides/index.rst
+++ b/source/guides/index.rst
@@ -24,3 +24,4 @@ introduction to packaging, see :doc:`/tutorials/index`.
    hosting-your-own-index
    migrating-to-pypi-org
    using-testpypi
+   making-a-pypi-friendly-readme

--- a/source/guides/making-a-pypi-friendly-readme.rst
+++ b/source/guides/making-a-pypi-friendly-readme.rst
@@ -1,0 +1,82 @@
+Making a PyPI-friendly README
+=============================
+
+README files can help your users understand your project and can be used to set your project's description on PyPI.
+This guide helps you:
+
+* create a README in a PyPI-friendly format
+* include your README in your package so it appears on PyPI
+* find resources for writing README content that will help your users
+
+
+Creating a README file
+----------------------
+
+README files are often named ``README`` or ``README.txt`` for plain-text READMEs,
+or :samp:`README.{extension}` where *extension* indicates a markup language
+(such as ``rst`` for reStructuredText or ``md`` for Markdown).
+
+For your README to display properly on PyPI, choose a markup language supported by PyPI.
+Formats supported by `PyPI's README renderer <https://github.com/pypa/readme_renderer>`_ are:
+
+* plain text
+* `reStructuredText <http://docutils.sourceforge.net/rst.html>`_
+* Markdown (`GitHub Flavored Markdown <https://github.github.com/gfm/>`_ by default,
+  or `CommonMark <http://commonmark.org/>`_)
+
+It's customary to save your README file in the root of your project, in the same directory as your ``setup.py`` file.
+
+
+Write your README file
+----------------------
+
+Your README file can contain whatever you want, but it's common to include information that helps your reader understand:
+
+* what your project is and how it can help them
+* how to install or use your project
+* where to go to contribute or get help
+
+For more information about writing READMEs, check out these resources:
+
+* `README checklist <https://github.com/ddbeck/readme-checklist>`_
+* `Awesome README <https://github.com/matiassingers/awesome-readme>`_
+
+
+Including your README in your package's metadata
+------------------------------------------------
+
+To include your README's contents as your package description,
+set your project's ``Description`` and ``Description-Content-Type`` metadata.
+
+For example, to set these values in your package's ``setup.py`` file,
+use ``setup()``'s ``long_description`` and ``long_description_content_type``.
+
+Set the value of ``long_description`` to the contents of the README file itself.
+Set the ``long_description_content_type`` to an accepted ``Content-Type``-style value for your README file's markup,
+such as ``text/plain``, ``text/x-rst`` (for reStructuredText), or ``text/markdown``.
+
+.. seealso::
+
+   * :any:`metadata_description`
+   * :any:`metadata_description_content_type`
+
+For example, see this example :file:`setup.py` file,
+which reads the contents of :file:`README.md` as ``long_description`` and
+identifies the markup as GitHub-flavored markdown:
+
+.. code-block:: python
+
+   from setuptools import setup
+
+   # read the contents of your README file
+   from os import path
+   this_directory = path.abspath(path.dirname(__file__))
+   with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+       long_description = f.read()
+
+   setup(
+       name='an_example_package',
+       # other arguments omitted
+       long_description=long_description,
+       long_description_content_type='text/markdown; variant=gfm'
+   )

--- a/source/specifications/core-metadata.rst
+++ b/source/specifications/core-metadata.rst
@@ -121,6 +121,8 @@ Example::
     Summary: A module for collecting votes from beagles.
 
 
+.. _metadata_description:
+
 Description (optional)
 ======================
 
@@ -164,6 +166,8 @@ Alternatively, the distribution's description may instead be provided in the
 message body (i.e., after a completely blank line following the headers, with
 no indentation or other special formatting necessary).
 
+
+.. _metadata_description_content_type:
 
 Description-Content-Type (optional)
 ===================================


### PR DESCRIPTION
This adds some guidelines for writing and setting metadata for READMEs that will play nicely with PyPI. This should cover a lot of the things discussed in #210.