### PR TITLE
Update pypi.python.org links to pypi.org links

### DIFF
--- a/source/discussions/deploying-python-applications.rst
+++ b/source/discussions/deploying-python-applications.rst
@@ -60,7 +60,7 @@ Windows
 Pynsist
 ^^^^^^^
 
-`Pynsist <https://pypi.python.org/pypi/pynsist>`__ is a tool that bundles Python
+`Pynsist <https://pypi.org/pypi/pynsist>`__ is a tool that bundles Python
 programs together with the Python-interpreter into a single installer based on
 NSIS. In most cases, packaging only requires the user to choose a version of
 the Python-interpreter and declare the dependencies of the program. The tool

--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -51,7 +51,7 @@ naming convention.
 
 .. _flask: https://flask.pocoo.org
 .. _Flask-SQLAlchemy: https://flask-sqlalchemy.pocoo.org/
-.. _Flask-Talisman: https://pypi.python.org/pypi/flask-talisman
+.. _Flask-Talisman: https://pypi.org/pypi/flask-talisman
 .. _simple API: https://www.python.org/dev/peps/pep-0503/#specification
 
 

--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -40,7 +40,7 @@ configured in a file located at ``$HOME/.pypirc``. If you see a file like:
         pypi
 
     [pypi]
-    repository:https://pypi.python.org/pypi
+    repository:https://pypi.org/pypi
     username:yourusername
     password:yourpassword
 

--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -40,8 +40,8 @@ number of your project:
     offers an API that both locations can use.
 
     Few tools you could use, in no particular order, and not necessarily complete:
-    `bumpversion <https://pypi.python.org/pypi/bumpversion>`_,
-    `changes <https://pypi.python.org/pypi/changes>`_, `zest.releaser <https://pypi.python.org/pypi/zest.releaser>`_.
+    `bumpversion <https://pypi.org/pypi/bumpversion>`_,
+    `changes <https://pypi.org/pypi/changes>`_, `zest.releaser <https://pypi.org/pypi/zest.releaser>`_.
 
 
 #.  Set the value to a ``__version__`` global variable in a dedicated module in
@@ -117,4 +117,4 @@ number of your project:
 
 #.  Keep the version number in the tags of a version control system (Git, Mercurial, etc)
     instead of in the code, and automatically extract it from there using
-    `setuptools_scm <https://pypi.python.org/pypi/setuptools_scm>`_.
+    `setuptools_scm <https://pypi.org/pypi/setuptools_scm>`_.

--- a/source/guides/supporting-multiple-python-versions.rst
+++ b/source/guides/supporting-multiple-python-versions.rst
@@ -93,7 +93,7 @@ for wrapping over the differences between Python 2 and Python 3. The six_
 package has enjoyed widespread use and may be regarded as a reliable way to
 write a single-source Python module that can be use in both Python 2 and 3.
 The six_ module can be used from as early as Python 2.5. A tool called
-`modernize <https://pypi.python.org/pypi/modernize>`_, developed by Armin
+`modernize <https://pypi.org/pypi/modernize>`_, developed by Armin
 Ronacher, can be used to automatically apply the code modifications provided
 by six_.
 

--- a/source/guides/tool-recommendations.rst
+++ b/source/guides/tool-recommendations.rst
@@ -102,5 +102,5 @@ migration, and what settings to change in your clients.
        :ref:`setuptools` in June 2013, thereby making setuptools the default
        choice for packaging.
 
-.. _distribute: https://pypi.python.org/pypi/distribute
+.. _distribute: https://pypi.org/pypi/distribute
 .. _venv: https://docs.python.org/3/library/venv.html

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -21,7 +21,7 @@ bandersnatch
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://bitbucket.org/pypa/bandersnatch/issues?status=new&status=open>`__ |
 `Bitbucket <https://bitbucket.org/pypa/bandersnatch>`__ |
-`PyPI <https://pypi.python.org/pypi/bandersnatch>`__
+`PyPI <https://pypi.org/pypi/bandersnatch>`__
 
 bandersnatch is a PyPI mirroring client designed to efficiently create a
 complete mirror of the contents of PyPI.
@@ -36,11 +36,11 @@ distlib
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://bitbucket.org/pypa/distlib/issues?status=new&status=open>`__ |
 `Bitbucket <https://bitbucket.org/pypa/distlib>`__ |
-`PyPI <https://pypi.python.org/pypi/distlib>`__
+`PyPI <https://pypi.org/pypi/distlib>`__
 
 Distlib is a library which implements low-level functions that relate to
 packaging and distribution of Python software.  It consists in part of the
-functions from the `distutils2 <https://pypi.python.org/pypi/Distutils2>`_
+functions from the `distutils2 <https://pypi.org/pypi/Distutils2>`_
 project, which was intended to be released as ``packaging`` in the Python 3.3
 stdlib, but was removed shortly before Python 3.3 entered beta testing.
 
@@ -54,7 +54,7 @@ packaging
 `Dev list <http://groups.google.com/group/pypa-dev>`__ |
 `Issues <https://github.com/pypa/packaging/issues>`__ |
 `Github <https://github.com/pypa/packaging>`__ |
-`PyPI <https://pypi.python.org/pypi/packaging>`__ |
+`PyPI <https://pypi.org/pypi/packaging>`__ |
 User irc:#pypa |
 Dev irc:#pypa-dev
 
@@ -71,7 +71,7 @@ pip
 `Dev list <http://groups.google.com/group/pypa-dev>`__ |
 `Issues <https://github.com/pypa/pip/issues>`__ |
 `Github <https://github.com/pypa/pip>`__ |
-`PyPI <https://pypi.python.org/pypi/pip/>`__ |
+`PyPI <https://pypi.org/pypi/pip/>`__ |
 User irc:#pypa |
 Dev irc:#pypa-dev
 
@@ -86,7 +86,7 @@ Pipenv
 `Docs <https://docs.pipenv.org>`__ |
 `Source <https://github.com/pypa/pipenv>`__ |
 `Issues <https://github.com/pypa/pipenv/issues>`__ |
-`PyPI <https://pypi.python.org/pypi/pipenv>`__
+`PyPI <https://pypi.org/pypi/pipenv>`__
 
 Pipenv is a project that aims to bring the best of all packaging worlds to the
 Python world. It harnesses :ref:`Pipfile`, :ref:`pip`, and :ref:`virtualenv`
@@ -129,7 +129,7 @@ setuptools
 `Dev list <http://groups.google.com/group/pypa-dev>`__ |
 `Issues <https://github.com/pypa/setuptools/issues>`__ |
 `GitHub <https://github.com/pypa/setuptools>`__ |
-`PyPI <https://pypi.python.org/pypi/setuptools>`__ |
+`PyPI <https://pypi.org/pypi/setuptools>`__ |
 User irc:#pypa  |
 Dev irc:#pypa-dev
 
@@ -150,7 +150,7 @@ twine
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://github.com/pypa/twine/issues>`__ |
 `Github <https://github.com/pypa/twine>`__ |
-`PyPI <https://pypi.python.org/pypi/twine>`__
+`PyPI <https://pypi.org/pypi/twine>`__
 
 Twine is a utility for interacting with PyPI, that offers a secure replacement for
 ``setup.py upload``.
@@ -167,7 +167,7 @@ virtualenv
 `Dev list <http://groups.google.com/group/pypa-dev>`__ |
 `Issues <https://github.com/pypa/virtualenv/issues>`__ |
 `Github <https://github.com/pypa/virtualenv>`__ |
-`PyPI <https://pypi.python.org/pypi/virtualenv/>`__ |
+`PyPI <https://pypi.org/pypi/virtualenv/>`__ |
 User irc:#pypa  |
 Dev irc:#pypa-dev
 
@@ -199,7 +199,7 @@ wheel
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://github.com/pypa/wheel/issues>`__ |
 `Bitbucket <https://github.com/pypa/wheel>`__ |
-`PyPI <https://pypi.python.org/pypi/wheel>`__ |
+`PyPI <https://pypi.org/pypi/wheel>`__ |
 User irc:#pypa  |
 Dev irc:#pypa-dev
 
@@ -221,7 +221,7 @@ bento
 `Mailing list <http://librelist.com/browser/bento>`__ |
 `Issues <https://github.com/cournape/Bento/issues>`__ |
 `Github <https://github.com/cournape/Bento>`__ |
-`PyPI <https://pypi.python.org/pypi/bento>`__
+`PyPI <https://pypi.org/pypi/bento>`__
 
 Bento is a packaging tool solution for Python software, targeted as an
 alternative to distutils, setuptools, distribute, etc....  Bento's philosophy is
@@ -235,7 +235,7 @@ buildout
 `Docs <http://www.buildout.org/en/latest/>`__ |
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://bugs.launchpad.net/zc.buildout>`__ |
-`PyPI <https://pypi.python.org/pypi/zc.buildout>`__ |
+`PyPI <https://pypi.org/pypi/zc.buildout>`__ |
 irc:#buildout
 
 Buildout is a Python-based build system for creating, assembling and deploying
@@ -273,7 +273,7 @@ devpi
 `Docs <http://doc.devpi.net/latest/>`__ |
 `Mailing List <https://groups.google.com/forum/#!forum/devpi-dev>`__ |
 `Issues <https://bitbucket.org/hpk42/devpi/issues>`__ |
-`PyPI <https://pypi.python.org/pypi/devpi>`__
+`PyPI <https://pypi.org/pypi/devpi>`__
 
 devpi features a powerful PyPI-compatible server and PyPI proxy cache with
 a complimentary command line tool to drive packaging, testing and release
@@ -285,7 +285,7 @@ flit
 
 `Docs <https://flit.readthedocs.io/en/latest/>`__ |
 `Issues <https://github.com/takluyver/flit/issues>`__ |
-`PyPI <https://pypi.python.org/pypi/flit>`__
+`PyPI <https://pypi.org/pypi/flit>`__
 
 Flit is a simple way to put Python packages and modules on PyPI. Flit packages
 a single importable module or package at a time, using the import name as the
@@ -298,7 +298,7 @@ enscons
 
 `Source <https://bitbucket.org/dholth/enscons/src>`__ |
 `Issues <https://bitbucket.org/dholth/enscons/issues>`__ |
-`PyPI <https://pypi.python.org/pypi/enscons>`__
+`PyPI <https://pypi.org/pypi/enscons>`__
 
 Enscons is a Python packaging tool based on `SCons`_. It builds pip-compatible
 source distributions and wheels without using distutils or setuptools,
@@ -330,7 +330,7 @@ pex
 
 `Docs <https://pex.readthedocs.io/en/latest/>`__ |
 `Github <https://github.com/pantsbuild/pex/>`__ |
-`PyPI <https://pypi.python.org/pypi/pex>`__
+`PyPI <https://pypi.org/pypi/pex>`__
 
 pex is both a library and tool for generating :file:`.pex` (Python EXecutable)
 files, standalone Python environments in the spirit of :ref:`virtualenv`.
@@ -416,4 +416,4 @@ information, see the section on :ref:`Creating and using Virtual Environments`.
 .. [2] Multiple projects reuse the distutils-sig mailing list as their user list.
 
 
-.. _distribute: https://pypi.python.org/pypi/distribute
+.. _distribute: https://pypi.org/pypi/distribute

--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -302,7 +302,7 @@ classifiers
   ],
 
 Provide a list of classifiers that categorize your project. For a full listing,
-see https://pypi.python.org/pypi?%3Aaction=list_classifiers.
+see https://pypi.org/classifiers/.
 
 Although the list of classifiers is often used to declare what Python versions
 a project supports, this information is only used for searching & browsing


### PR DESCRIPTION
Fixes #476 

Updated `pypi.python.org` links to `pypi.org` links.
Changed `https://pypi.python.org/pypi?%3Aaction=list_classifiers` to `https://pypi.org/classifiers/`