### PR TITLE
Reword uploading section in tutorial

### DIFF
--- a/source/tutorials/distributing-packages.rst
+++ b/source/tutorials/distributing-packages.rst
@@ -903,9 +903,14 @@ Upload your distributions
 -------------------------
 
 Once you have an account you can upload your distributions to
-:term:`PyPI <Python Package Index (PyPI)>` using :ref:`twine`. If this is
-your first time uploading a distribution for a new project, twine will handle
-registering the project.
+:term:`PyPI <Python Package Index (PyPI)>` using :ref:`twine`.
+
+The process for uploading a release is the same regardless of whether
+or not the project already exists on PyPI - if it doesn't exist yet,
+it will be automatically created when the first release is uploaded.
+
+For the second and subsequent releases, PyPI only requires that the
+version number of the new release differ from any previous releases.
 
 .. code-block:: text
 


### PR DESCRIPTION
The previous wording didn't make it clear that this step remains
the same regardless of whether or not this is the first release for
a project.

It also suggest that only twine auto-registered projects, which
is no longer the case - Warehouse *only* offers auto-registration.

Partially addresses #114 (a full resolution will require more guidance
on managing version numbers)