### PR TITLE
Remove pointer to now-sunset legacy PyPI

### DIFF
--- a/source/guides/migrating-to-pypi-org.rst
+++ b/source/guides/migrating-to-pypi-org.rst
@@ -133,12 +133,3 @@ Managing published packages and releases
 
 ``pypi.org`` provides a fully functional interface for logged in users to
 manage their published packages and releases.
-
-Visiting legacy PyPI
---------------------
-
-A temporary installation of the legacy PyPI codebase is `available at
-legacy.pypi.org <http://legacy.pypi.org/>`_ until 30 April 2018, when
-it will be shut down. It reads from the same database backend and file
-store as pypi.org. See `the Warehouse roadmap
-<https://wiki.python.org/psf/WarehouseRoadmap>`_ for further details.


### PR DESCRIPTION
Per https://mail.python.org/mm3/archives/list/distutils-sig@python.org/thread/YREMU56QKRMTTFBFVFJ2B4EHOEKOJZFJ/ .