### PR TITLE
Fix bad filename for README in packaging tutorial

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -70,7 +70,7 @@ the values if you want:
 
     import setuptools
 
-    with open("README.rst", "r") as fh:
+    with open("README.md", "r") as fh:
         long_description = fh.read()
 
     setuptools.setup(


### PR DESCRIPTION
Closes https://github.com/pypa/packaging-problems/issues/153