### PR TITLE
Redirect to respective PyPI projects' URL

### DIFF
--- a/source/guides/creating-and-discovering-plugins.rst
+++ b/source/guides/creating-and-discovering-plugins.rst
@@ -49,8 +49,8 @@ Using naming convention for plugins also allows you to query the
 Python Package Index's `simple API`_ for all packages that conform to your
 naming convention.
 
-.. _flask: https://flask.pocoo.org
-.. _Flask-SQLAlchemy: https://flask-sqlalchemy.pocoo.org/
+.. _Flask: https://pypi.org/project/Flask/
+.. _Flask-SQLAlchemy: https://pypi.org/project/Flask-SQLAlchemy/
 .. _Flask-Talisman: https://pypi.org/project/flask-talisman
 .. _simple API: https://www.python.org/dev/peps/pep-0503/#specification
 


### PR DESCRIPTION
Fixed broken hyperlinks for `Flask` and `Flask-SQLAlchemy` targeted texts appearing in [Creating and discovering plugins](https://packaging.python.org/guides/creating-and-discovering-plugins/) guide.
Fixes #523 