### PR TITLE
updating the information on the doc related to the correct url

### DIFF
--- a/source/guides/using-testpypi.rst
+++ b/source/guides/using-testpypi.rst
@@ -28,7 +28,7 @@ in the ``--repository-url`` flag
 
 .. code::
 
-    $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+    $ twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 
 The ``legacy`` in the URL above refers to the legacy API for PyPI, which may
 change as the Warehouse project progresses.

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -249,7 +249,7 @@ Once installed, run Twine to upload all of the archives under :file:`dist`:
 
 .. code-block:: bash
 
-    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+    twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 
 You will be prompted for the username and password you registered with Test
 PyPI. After the command completes, you should see output similar to this:


### PR DESCRIPTION
Hi,

Actually following the docs I got error, after do a simple research I got a lot of cases related to the same issue and the fix is just related to the url, just changing according below

from
---
twine upload --repository-url https://test.pypi.org/legacy/ dist/*
---

to
---
twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
---

I believe this change will upload the online docs and to the next *new users* which try to upload their packages, everything will be fine.

Thank you.