### PR TITLE
Continuum Analytics changed its name to Anaconda

### DIFF
--- a/source/guides/installing-scientific-packages.rst
+++ b/source/guides/installing-scientific-packages.rst
@@ -128,7 +128,7 @@ The conda cross-platform package manager
 ----------------------------------------
 
 `Anaconda <https://www.anaconda.com/download/>`_ is a Python distribution
-published by Continuum Analytics. It is a stable collection of Open Source
+published by Anaconda, Inc. It is a stable collection of Open Source
 packages for big data and scientific use.  As of the 5.0 release of Anaconda,
 about 200 packages are installed by default, and a total of 400-500 can be
 installed and updated from the Anaconda repository.

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -251,9 +251,9 @@ conda
 `Docs <http://conda.pydata.org/docs/>`__
 
 conda is the package management tool for `Anaconda
-<http://docs.continuum.io/anaconda/index.html>`__ Python installations.
-Anaconda Python is a distribution from `Continuum Analytics
-<http://continuum.io/downloads>`__ specifically aimed at the scientific
+<https://docs.anaconda.com/anaconda/>`__ Python installations.
+Anaconda Python is a distribution from `Anaconda, Inc
+<https://www.anaconda.com/download>`__ specifically aimed at the scientific
 community, and in particular on Windows where the installation of binary
 extensions is often difficult.
 
@@ -262,7 +262,7 @@ many of their combined features in terms of package management, virtual environm
 management and deployment of binary extensions.
 
 Conda does not install packages from PyPI and can install only from
-the official Continuum repositories, or anaconda.org (a place for
+the official Anaconda repositories, or anaconda.org (a place for
 user-contributed *conda* packages), or a local (e.g. intranet) package server.
 However, note that pip can be installed into, and work side-by-side with conda
 for managing distributions from PyPI.


### PR DESCRIPTION
xref: https://www.anaconda.com/blog/company-blog/continuum-analytics-officially-becomes-anaconda/