### PR TITLE
Move the Overview to a task based lead in along with the others

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -33,8 +33,6 @@ happily accept any :doc:`contributions and feedback <contribute>`. 😊
 Get started
 ===========
 
-Thinking about shipping a new Python library or application? Start with :doc:`overview`.
-
 Essential tools and concepts for working within the Python
 development ecosystem are covered in our :doc:`tutorials/index` section:
 
@@ -44,6 +42,9 @@ development ecosystem are covered in our :doc:`tutorials/index` section:
   :doc:`tutorial on managing application dependencies <tutorials/managing-dependencies>`.
 * to learn how to package and distribute your projects, see the
   :doc:`tutorial on packaging and distributing <tutorials/packaging-projects>`
+* to get an overview of Python's packaging options, see the
+  :doc:`Overview of Python Packaging <overview>`.
+
 
 Learn more
 ==========


### PR DESCRIPTION
This moves the overview that was added in #519 from a dedicated call out at the start of the "Get Started" section, into the list of task based documents.

The overview document is not the globally correct choice for users hitting this page who want to get started-- often these users will be looking for a simple tutorial that just tells them what to do rather than a deep dive into all of the various options they *could* pick. The new location brings these different tasks ("I want an overview" vs "I want to package software" vs "I want to manage dependencies for an application" vs "I want to install software") back into alignment with each other, and generally fits the overall feel of python.packaging.org better.