### PR TITLE
Clarify that the overview also covers non-Python packaging options

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -42,8 +42,8 @@ development ecosystem are covered in our :doc:`tutorials/index` section:
   :doc:`tutorial on managing application dependencies <tutorials/managing-dependencies>`.
 * to learn how to package and distribute your projects, see the
   :doc:`tutorial on packaging and distributing <tutorials/packaging-projects>`
-* to get an overview of Python's packaging options, see the
-  :doc:`Overview of Python Packaging <overview>`.
+* to get an overview of packaging options for Python libraries and
+  applications, see the :doc:`Overview of Python Packaging <overview>`.
 
 
 Learn more


### PR DESCRIPTION
Reopening #541 post-squash freshening, quoth:

> While I appreciate the expeditious velocity in #540, I agree with @dstufft that the wording needs some work. The overview does not cover "Python's packaging options", but rather "options for packaging Python libraries and applications". In fact, most of the options do not originate from official Python efforts or groups.

TLDR: "an overview of Python's packaging options" -> "an overview of packaging options for Python libraries and applications"