### PR TITLE
Fix tutorials/packaging-project's setup.py example to specify classifiers as a list.

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -83,11 +83,11 @@ the values if you want:
         long_description_content_type="text/markdown",
         url="https://github.com/pypa/sampleproject",
         packages=setuptools.find_packages(),
-        classifiers=(
+        classifiers=[
             "Programming Language :: Python :: 3",
             "License :: OSI Approved :: MIT License",
             "Operating System :: OS Independent",
-        ),
+        ],
     )
 
 


### PR DESCRIPTION
Fixes #543