### PR TITLE
Fix tutorials/packaging-project's twine example

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -249,7 +249,7 @@ Once installed, run Twine to upload all of the archives under :file:`dist`:
 
 .. code-block:: bash
 
-    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+    python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 You will be prompted for the username and password you registered with Test
 PyPI. After the command completes, you should see output similar to this:


### PR DESCRIPTION
In some operations systems such as mine (macOS Mojave 10.14 Beta (18A365a)), after installing twine the system can not find twine unless you call it explicatively.