### PR TITLE
Link back to the spec process page

### DIFF
--- a/source/specifications/index.rst
+++ b/source/specifications/index.rst
@@ -2,7 +2,10 @@ PyPA specifications
 ###################
 
 This is a list of currently active interoperability specifications maintained
-by the Python Packaging Authority.
+by the Python Packaging Authority. The process for updating these standards,
+and for proposing new ones, is documented on
+`pypa.io <https://www.pypa.io/en/latest/specifications/>`__.
+
 
 Package Distribution Metadata
 -----------------------------


### PR DESCRIPTION
Without a backlink from the specifications page to the process
page, it isn't obvious how things currently work.