### PR TITLE
Replace tar command with something that works

### DIFF
--- a/source/guides/dropping-older-python-versions.rst
+++ b/source/guides/dropping-older-python-versions.rst
@@ -69,7 +69,7 @@ The file contains a set of keys and values, the list of keys is part of the PyPa
 
 You can see the contents of the generated file like this::
 
-    tar xfz dist/my-package-1.0.0.tar.gz --wildcards --no-wildcards-match-slash -O '*/PKG-INFO'
+    tar xfO dist/my-package-1.0.0.tar.gz my-package-1.0.0/PKG-INFO
 
 Validate that the following is in place, before publishing the package:
 

--- a/source/guides/dropping-older-python-versions.rst
+++ b/source/guides/dropping-older-python-versions.rst
@@ -69,7 +69,7 @@ The file contains a set of keys and values, the list of keys is part of the PyPa
 
 You can see the contents of the generated file like this::
 
-    tar xvfz dist/my-package-1.0.0.tar.gz -O | cat */PKG-INFO
+    tar xfz dist/my-package-1.0.0.tar.gz --wildcards --no-wildcards-match-slash -O '*/PKG-INFO'
 
 Validate that the following is in place, before publishing the package:
 


### PR DESCRIPTION
In the "Dropping support for older Python versions" guide, the tar command given for showing the sdist's metadata does not work (unless you happen to run it in your project directory without cleaning up your `.egg-info` dir first, in which case it only works by accident and the `tar` is pointless).  This pull request changes the command to something that does work.