### PR TITLE
Mention not using Sphinx extensions in "Making a PyPI-friendly README"

### DIFF
--- a/source/guides/making-a-pypi-friendly-readme.rst
+++ b/source/guides/making-a-pypi-friendly-readme.rst
@@ -14,7 +14,7 @@ For your README to display properly on PyPI, choose a markup language supported 
 Formats supported by `PyPI's README renderer <https://github.com/pypa/readme_renderer>`_ are:
 
 * plain text
-* `reStructuredText <http://docutils.sourceforge.net/rst.html>`_
+* `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ (without Sphinx extensions)
 * Markdown (`GitHub Flavored Markdown <https://github.github.com/gfm/>`_ by default,
   or `CommonMark <http://commonmark.org/>`_)
 
@@ -88,6 +88,12 @@ Validating reStructuredText markup
 
 If your README is written in reStructuredText, any invalid markup will prevent
 it from rendering, causing PyPI to instead just show the README's raw source.
+
+Note that Sphinx extensions used in docstrings, such as
+`directives and roles <http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_ 
+(e.g., "``:py:func:`getattr```" or "``:ref:`my-reference-label```"), are not allowed here and will result in error
+messages like "``Error: Unknown interpreted text role "py:func".``".
+
 You can check your README for markup errors before uploading as follows:
 
 1. Install the latest version of `twine <https://github.com/pypa/twine>`_;


### PR DESCRIPTION
I thought I was doing the right thing by including [Sphinx cross-references](http://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing-python-objects)
in my `README.rst` and through that in my package's `long_description`, but only after
several failed validations and searching did I learn that Sphinx extensions are not allowed.

The error message from `twine check` (or `rst-lint`) is not obvious about what is wrong: e.g.,
'Error: Unknown interpreted text role "py:func".' and to those just figuring out Sphinx and rST
the distinction is not necessarily obvious.

(I am submitting this PR against "master" because the other 2 open PRs do that; I read the contributing guide but it gave no advice about which branch to use.)