### PR TITLE
Change bumpversion to bump2version

### DIFF
--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -40,7 +40,7 @@ number of your project:
     offers an API that both locations can use.
 
     Few tools you could use, in no particular order, and not necessarily complete:
-    `bumpversion <https://pypi.org/project/bumpversion>`_,
+    `bump2version <https://pypi.org/project/bump2version>`_,
     `changes <https://pypi.org/project/changes>`_, `zest.releaser <https://pypi.org/project/zest.releaser>`_.
 
 


### PR DESCRIPTION
Change the bumpversion to bump2version in the list of tools to manage version.

Bumpversion has not received an update since 2015. [bump2version](https://pypi.org/project/bump2version/) is a fork that is being maintained.

The maintainer of bumpversion has stated
>I should probably add a sunsetting notice to the top of the README, saying this is not actively maintained and people should switch to one of the forked versions.

--https://github.com/peritus/bumpversion/issues/169#issuecomment-339023681