### PR TITLE
Add example for single-sourcing pgk ver using pkg_resources

### DIFF
--- a/source/guides/single-sourcing-package-version.rst
+++ b/source/guides/single-sourcing-package-version.rst
@@ -96,6 +96,8 @@ number of your project:
     installation metadata, which is not necessarily the code that's currently
     imported.
 
+    Example using this technique: `setuptools <https://github.com/pypa/setuptools/blob/master/setuptools/version.py>`_.
+
 
 #.  Set the value to ``__version__`` in ``sample/__init__.py`` and import
     ``sample`` in :file:`setup.py`.


### PR DESCRIPTION
Add `setuptools` as an example of single-sourcing package versioning using `pkg_resources`.