### PR TITLE
Remove landing page link to PyPI migration guide

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -31,8 +31,6 @@ happily accept any :doc:`contributions and feedback <contribute>`. 😊
 .. _GitHub: https://github.com/pypa/python-packaging-user-guide
 .. _Python Packaging Authority: https://pypa.io
 
-.. note:: Looking for guidance on migrating from legacy PyPI to :term:`pypi.org`?
-   Please see :doc:`guides/migrating-to-pypi-org`.
 
 Get started
 ===========


### PR DESCRIPTION
The migration is complete. ;)

I've let the guide stay, as a historical record. I don't think it'd serve much use though now, since the migration is over, so I'll be happy to delete the file if that's what we want to do.
