### PR TITLE
python3: virtualenv module is now venv

### DIFF
--- a/source/guides/installing-using-pip-and-virtualenv.rst
+++ b/source/guides/installing-using-pip-and-virtualenv.rst
@@ -104,13 +104,15 @@ On macOS and Linux:
 
 .. code-block:: bash
 
-    python3 -m virtualenv env
+    python3 -m venv env
+    OR
+    python -m virtualenv env
 
 On Windows:
 
 .. code-block:: bash
 
-    py -m virtualenv env
+    py -m venv env
 
 The second argument is the location to create the virtualenv. Generally, you
 can just create this in your project and call it ``env``.


### PR DESCRIPTION
Updating the docs to match Python 3.7.1 on Mac.
See below for proof of change.

Divyes-MacBook-Air:~ divyekapoor$ python3 --version
Python 3.7.1
Divyes-MacBook-Air:~ divyekapoor$ python3 -m virtualenv
/usr/local/opt/python/bin/python3.7: No module named virtualenv
Divyes-MacBook-Air:~ divyekapoor$ python3 -m venv
usage: venv [-h] [--system-site-packages] [--symlinks | --copies] [--clear]
            [--upgrade] [--without-pip] [--prompt PROMPT]
            ENV_DIR [ENV_DIR ...]
...