### PR TITLE
Reference twine from Python3

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -249,7 +249,7 @@ Once installed, run Twine to upload all of the archives under :file:`dist`:
 
 .. code-block:: bash
 
-    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+    python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 You will be prompted for the username and password you registered with Test
 PyPI. After the command completes, you should see output similar to this:


### PR DESCRIPTION
pip doesn't necessarily add it to the path.