### PR TITLE
Add more clarity to the packaging tutorial dir structure

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -48,7 +48,7 @@ them in the following steps.
 
 .. code-block:: text
 
-    /example_pkg
+    /packaging_tutorial
       /example_pkg
         __init__.py
       setup.py

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -17,13 +17,13 @@ To create this project locally, create the following file structure:
 
 .. code-block:: text
 
-    /example_pkg
+    /packaging_tutorial
       /example_pkg
         __init__.py
 
 
 Once you create this structure, you'll want to run all of the commands in this
-tutorial within the top-level folder - so be sure to ``cd example_pkg``.
+tutorial within the top-level folder - so be sure to ``cd packaging_tutorial``.
 
 You should also edit :file:`example_pkg/__init__.py` and put the following
 code in there:


### PR DESCRIPTION
The tutorial begins by instructing the reader to create this confusing hierarchy without explanation:

```
example_pkg/
    example_pkg/
        __init__.py
```

The tutorial then continues on, referring to `example_pkg` frequently, but not clarifying _which_ one is meant. Confusing! And not necessary, in my opinion. So this PR renames the top-level dir, better describing its purpose:

```
packaging_tutorial/
    example_pkg/
        __init__.py
```