### PR TITLE
add instructions to install python CLI applications with pipx

### DIFF
--- a/source/guides/index.rst
+++ b/source/guides/index.rst
@@ -10,6 +10,7 @@ introduction to packaging, see :doc:`/tutorials/index`.
 
    tool-recommendations
    installing-using-pip-and-virtualenv
+   installing-stand-alone-command-line-tools
    installing-using-linux-tools
    installing-scientific-packages
    multi-version-installs

--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -13,10 +13,10 @@ can cause version conflicts and break dependencies the operating system has
 on Python packages.
 
 `pipx <https://github.com/pipxproject/pipx>`_ solves this by creating a virtual
-environment for each package. It then symlinks each package's applications to a directory
-that is on your ``$PATH``. This allows each package to be upgraded or uninstalled without
-causing conflicts with other packages, and allows you to safely run the program
-from anywhere.
+environment for each package, while also ensuring that package's applications
+are accessible through a directory that is on your ``$PATH``. This allows each
+package to be upgraded or uninstalled without causing conflicts with other
+packages, and allows you to safely run the program from anywhere.
 
 .. Note:: pipx only works with Python 3.6+.
 

--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -12,9 +12,9 @@ but installing packages and their dependencies to the same global environment
 can cause version conflicts and break dependencies the operating system has
 on Python packages.
 
-`pipx <https://github.com/pipxproject/pipx>`_ solves this by creating a virtual environment for
-each package. It then makes the entry points globally accessible by adding them
-to your $PATH. This allows each package to be upgraded or uninstalled without
+`pipx <https://github.com/pipxproject/pipx>`_ solves this by creating a virtual
+environment for each package. It then symlinks each package's applications to a directory
+that is on your ``$PATH``. This allows each package to be upgraded or uninstalled without
 causing conflicts with other packages, and allows you to safely run the program
 from anywhere.
 
@@ -87,7 +87,7 @@ To upgrade or uninstall the package
 
 ::
 
-  $ pip upgrade pipx
+  $ pip install -U pipx
   $ pip uninstall pipx
 
 ``pipx`` also allows you to install and run the latest version of a cli tool

--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -12,44 +12,83 @@ but installing packages and their dependencies to the same global environment
 can cause version conflicts and break dependencies the operating system has
 on Python packages.
 
-``pipx-app`` solves this by creating a virtual environment for
+`pipx <https://github.com/pipxproject/pipx>`_ solves this by creating a virtual environment for
 each package. It then makes the entry points globally accessible by adding them
 to your $PATH. This allows each package to be upgraded or uninstalled without
 causing conflicts with other packages, and allows you to safely run the program
 from anywhere.
 
-.. Note:: ``pipx`` only works with Python 3.6+.
+.. Note:: pipx only works with Python 3.6+.
 
-``pipx`` is installed with ``pipx-bootstrap``:
+``pipx`` is installed with ``pip``:
 
 ::
 
-  $ pip install --user pipx-bootstrap
-  $ pipx-bootstrap
-  $ pip uninstall pipx-bootstrap
+  $ pip install --user pipx
+  $ pipx ensurepath  # ensures the path of the CLI application directory is on your $PATH
 
 .. Note:: You may need to restart your terminal for the path updates to take effect.
 
-Now you can install packages and access their entry points from anywhere.
+Now you can install packages with ``pipx install`` and access the package's entry point(s) from anywhere.
 
 ::
 
   $ pipx install PACKAGE
-  $ ENTRYPOINT_OF_PACKAGE
+  $ ENTRYPOINT_OF_PACKAGE [ARGS]
 
-To upgrade or uninstall
+For example
+
+::
+
+  $ pipx install cowsay
+    installed package cowsay 2.0, Python 3.6.2+
+    These binaries are now globally available
+      - cowsay
+  done! ✨ 🌟 ✨
+  $ cowsay moo
+    ___
+  < moo >
+    ===
+          \
+           \
+             ^__^
+             (oo)\_______
+             (__)\       )\/       ||----w |
+                 ||     ||
+
+To see a list of packages installed with pipx and which CLI applications are available, use ``pipx list``.
+
+::
+
+  $ pipx list
+  venvs are in /Users/user/.local/pipx/venvs
+  symlinks to binaries are in /Users/user/.local/bin
+     package black 18.9b0, Python 3.6.2+
+      - black
+      - blackd
+     package cowsay 2.0, Python 3.6.2+
+      - cowsay
+     package mypy 0.660, Python 3.6.2+
+      - dmypy
+      - mypy
+      - stubgen
+     package nox 2018.10.17, Python 3.6.2+
+      - nox
+      - tox-to-nox
+
+To upgrade or uninstall the package
 
 ::
 
   $ pipx upgrade PACKAGE
   $ pipx uninstall PACKAGE
 
-``pipx`` can modify itself too. To upgrade or uninstall ``pipx``
+``pipx`` can be upgraded or uninstalled with pip
 
 ::
 
-  $ pipx upgrade pipx-app
-  $ pipx uninstall pipx-app
+  $ pip upgrade pipx
+  $ pip uninstall pipx
 
 ``pipx`` also allows you to install and run the latest version of a cli tool
 in a temporary, ephemeral environment.
@@ -58,10 +97,17 @@ in a temporary, ephemeral environment.
 
   $ pipx run PACKAGE [ARGS]
 
+For example
+
+::
+
+  $ pipx run cowsay moooo
+
 To see the full list of commands ``pipx`` offers, run
 
 ::
 
   $ pipx --help
 
-You can learn more about ``pipx`` at its homepage, https://github.com/cs01/pipx.
+You can learn more about ``pipx`` at its homepage,
+https://github.com/pipxproject/pipx.

--- a/source/guides/installing-stand-alone-command-line-tools.rst
+++ b/source/guides/installing-stand-alone-command-line-tools.rst
@@ -1,0 +1,67 @@
+Installing stand alone command line tools
+=========================================
+
+Many packages have command line entry points. Examples of this type of application are
+`mypy <https://github.com/python/mypy>`_,
+`flake8 <https://github.com/PyCQA/flake8>`_,
+`pipenv <https://github.com/pypa/pipenv>`_,and
+`black <https://github.com/ambv/black>`_.
+
+Usually you want to be able to access these from anywhere,
+but installing packages and their dependencies to the same global environment
+can cause version conflicts and break dependencies the operating system has
+on Python packages.
+
+``pipx-app`` solves this by creating a virtual environment for
+each package. It then makes the entry points globally accessible by adding them
+to your $PATH. This allows each package to be upgraded or uninstalled without
+causing conflicts with other packages, and allows you to safely run the program
+from anywhere.
+
+.. Note:: ``pipx`` only works with Python 3.6+.
+
+``pipx`` is installed with ``pipx-bootstrap``:
+
+::
+
+  $ pip install --user pipx-bootstrap
+  $ pipx-bootstrap
+  $ pip uninstall pipx-bootstrap
+
+.. Note:: You may need to restart your terminal for the path updates to take effect.
+
+Now you can install packages and access their entry points from anywhere.
+
+::
+
+  $ pipx install PACKAGE
+  $ ENTRYPOINT_OF_PACKAGE
+
+To upgrade or uninstall
+
+::
+
+  $ pipx upgrade PACKAGE
+  $ pipx uninstall PACKAGE
+
+``pipx`` can modify itself too. To upgrade or uninstall ``pipx``
+
+::
+
+  $ pipx upgrade pipx-app
+  $ pipx uninstall pipx-app
+
+``pipx`` also allows you to install and run the latest version of a cli tool
+in a temporary, ephemeral environment.
+
+::
+
+  $ pipx run PACKAGE [ARGS]
+
+To see the full list of commands ``pipx`` offers, run
+
+::
+
+  $ pipx --help
+
+You can learn more about ``pipx`` at its homepage, https://github.com/cs01/pipx.

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -346,9 +346,9 @@ make deployment of Python applications as simple as ``cp``.
 pipx
 ====
 
-`Docs <https://github.com/pipxproject/pipx-app>`__ |
-`Github <https://github.com/pipxproject/pipx-app>`__ |
-`PyPI <https://pypi.org/project/pipx-app/>`__
+`Docs <https://github.com/pipxproject/pipx>`__ |
+`Github <https://github.com/pipxproject/pipx>`__ |
+`PyPI <https://pypi.org/project/pipx/>`__
 
 pipx is a tool to safely install and run Python CLI applications globally.
 

--- a/source/key_projects.rst
+++ b/source/key_projects.rst
@@ -21,7 +21,7 @@ bandersnatch
 `Mailing list <http://mail.python.org/mailman/listinfo/distutils-sig>`__ [2]_ |
 `Issues <https://github.com/pypa/bandersnatch/issues>`__ |
 `Github <https://github.com/pypa/bandersnatch>`__ |
-`PyPI <https://pypi.org/project/bandersnatch>`__ | 
+`PyPI <https://pypi.org/project/bandersnatch>`__ |
 Dev irc:#bandersnatch
 
 bandersnatch is a PyPI mirroring client designed to efficiently create a
@@ -340,6 +340,17 @@ files, standalone Python environments in the spirit of :ref:`virtualenv`.
 :file:`.pex` files are just carefully constructed zip files with a
 ``#!/usr/bin/env python`` and special :file:`__main__.py`, and are designed to
 make deployment of Python applications as simple as ``cp``.
+
+.. _pipx:
+
+pipx
+====
+
+`Docs <https://github.com/pipxproject/pipx-app>`__ |
+`Github <https://github.com/pipxproject/pipx-app>`__ |
+`PyPI <https://pypi.org/project/pipx-app/>`__
+
+pipx is a tool to safely install and run Python CLI applications globally.
 
 .. _scikit-build:
 

--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -161,7 +161,9 @@ Creating Virtual Environments
 
 Python "Virtual Environments" allow Python :term:`packages <Distribution
 Package>` to be installed in an isolated location for a particular application,
-rather than being installed globally.
+rather than being installed globally. If you are looking to safely install
+global command line tools,
+see :doc:`/guides/installing-stand-alone-command-line-tools`.
 
 Imagine you have an application that needs version 1 of LibFoo, but another
 application requires version 2. How can you use both these applications? If you
@@ -471,49 +473,6 @@ Install `setuptools extras`_.
   $ pip install SomePackage[PDF]==3.0
   $ pip install -e .[PDF]==3.0  # editable project in current directory
 
-
-Installing Python Command Line Applications Globally
-==========================================================
-
-Many packages have command line entry points. Examples of this type of application are
-`mypy <https://github.com/python/mypy>`_,
-`flake8 <https://github.com/PyCQA/flake8>`_, and
-`black <https://github.com/ambv/black>`_.
-
-Usually you want to be able to access these from anywhere,
-but it is not ideal to install the packages and their dependencies to the same
-environment.
-
-``pipx-app`` solves this by creating a virtual environment for
-each package. It then makes the entry points globally accessible by adding them
-to your $PATH. This allows each package to be upgraded or uninstalled without
-causing conflicts with other packages, and allows you to safely run the program
-from anywhere.
-
-.. Note:: ``pipx-app`` only works with Python 3.6+.
-
-Install ``pipx-app`` with the following commands:
-
-::
-
-  $ pip install --user pipx-bootstrap
-  $ pipx-bootstrap
-  $ pip uninstall pipx-bootstrap
-
-Now you can install packages and access their entry points from anywhere.
-
-::
-
-  $ pipx install PACKAGE
-  $ ENTRYPOINT_OF_PACKAGE
-
-To see instructions on how to use ``pipx``, run
-
-::
-
-  $ pipx --help
-
-You can learn more about ``pipx`` at its homepage, https://github.com/cs01/pipx.
 
 ----
 

--- a/source/tutorials/installing-packages.rst
+++ b/source/tutorials/installing-packages.rst
@@ -472,6 +472,48 @@ Install `setuptools extras`_.
   $ pip install -e .[PDF]==3.0  # editable project in current directory
 
 
+Installing Python Command Line Applications Globally
+==========================================================
+
+Many packages have command line entry points. Examples of this type of application are
+`mypy <https://github.com/python/mypy>`_,
+`flake8 <https://github.com/PyCQA/flake8>`_, and
+`black <https://github.com/ambv/black>`_.
+
+Usually you want to be able to access these from anywhere,
+but it is not ideal to install the packages and their dependencies to the same
+environment.
+
+``pipx-app`` solves this by creating a virtual environment for
+each package. It then makes the entry points globally accessible by adding them
+to your $PATH. This allows each package to be upgraded or uninstalled without
+causing conflicts with other packages, and allows you to safely run the program
+from anywhere.
+
+.. Note:: ``pipx-app`` only works with Python 3.6+.
+
+Install ``pipx-app`` with the following commands:
+
+::
+
+  $ pip install --user pipx-bootstrap
+  $ pipx-bootstrap
+  $ pip uninstall pipx-bootstrap
+
+Now you can install packages and access their entry points from anywhere.
+
+::
+
+  $ pipx install PACKAGE
+  $ ENTRYPOINT_OF_PACKAGE
+
+To see instructions on how to use ``pipx``, run
+
+::
+
+  $ pipx --help
+
+You can learn more about ``pipx`` at its homepage, https://github.com/cs01/pipx.
 
 ----
 


### PR DESCRIPTION
pipx (https://github.com/cs01/pipx) is a command execution tool like pipsi, and was mentioned in this thread.  https://github.com/pypa/python-packaging-user-guide/issues/406

Pipsi is no longer maintained, and pipx (my project) hopes to pick up where pipsi left off. 

I took a shot at adding a section to the installation tutorial. I think this type of tool provides a lot of value to the python community yet doesn’t seem to be very well known. Hopefully this will change that 😄 .