### PR TITLE
fix(link): replace dead link to active

### DIFF
--- a/source/guides/appveyor-sample/appveyor.yml
+++ b/source/guides/appveyor-sample/appveyor.yml
@@ -3,7 +3,7 @@ environment:
   matrix:
 
     # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
+    # https://www.appveyor.com/docs/windows-images-software/#python
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 


### PR DESCRIPTION
### 1. Summary

At 2018 AppVeyor on Linux [**is available**](https://www.appveyor.com/blog/2018/05/15/appveyor-for-linux-is-generally-available/). List of pre-installed software will be split:

+ [**Windows**](https://www.appveyor.com/docs/windows-images-software)
+ [**Linux**](https://www.appveyor.com/docs/linux-images-software)

I replace old broken link to link, specific for Windows.

Thanks.